### PR TITLE
feat: add milestone 1 WebView score renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,24 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/AndroidProjectSystem.xml
+/.idea/compiler.xml
+/.idea/copilot.data.migration.ask2agent.xml
+/.idea/deploymentTargetSelector.xml
+/.idea/gradle.xml
+/.idea/inspectionProfiles/
+/.idea/kotlinc.xml
+/.idea/markdown.xml
+/.idea/misc.xml
+/.idea/runConfigurations.xml
+/.idea/vcs.xml
 .DS_Store
 /build
 /captures
 .externalNativeBuild
 .cxx
 local.properties
+
+# Local AI agent instructions and skills
+AGENTS.md
+.agents/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ClefRun
+# Contributing to Clefrun
 
 This repo uses **feature branches** + **Conventional Commits** to keep work reviewable and history clean.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to ClefRun
+
+This repo uses **feature branches** + **Conventional Commits** to keep work reviewable and history clean.
+
+Reference: https://www.conventionalcommits.org/en/v1.0.0/
+
+---
+
+## Workflow
+
+### 1) Create a branch for every change
+Do **not** commit directly to `main`. Always branch.
+
+**Branch naming**
+- `feat/<short-description>` — new functionality
+- `fix/<short-description>` — bug fixes
+- `chore/<short-description>` — tooling, build, docs chores
+- `docs/<short-description>` — documentation-only changes (optional)
+- `refactor/<short-description>` — refactors without behavior changes (optional)
+
+**Examples**
+- `feat/m2-core-writer`
+- `feat/m3-beginner-generator`
+- `fix/webview-js-escaping`
+- `chore/add-commitlint`
+- `docs/readme-smoke-test`
+
+**Commands**
+```bash
+git checkout main
+git pull
+git checkout -b feat/m2-core-writer
+```

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ This milestone proves that Android Compose can host a `WebView`, load `app/src/m
 
 ### Current limitation
 
-`score.html` loads OpenSheetMusicDisplay from a CDN, so the device or emulator needs network access for this milestone.
+`score.html` loads OpenSheetMusicDisplay from a CDN (SRI-pinned), so the device or emulator needs network access for this milestone.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Clefrun
+
+## Milestone 1 smoke test
+
+This milestone proves that Android Compose can host a `WebView`, load `app/src/main/assets/score.html`, and render a hardcoded 4-bar grand staff MusicXML example through OpenSheetMusicDisplay.
+
+### Run
+
+- Build from the project root with `./gradlew assembleDebug`
+- Install/run the `app` module from Android Studio or with your usual debug install flow
+
+### Click path
+
+1. Launch the app.
+2. Wait for the `WebView OSMD Render Test` screen to appear.
+3. Tap `Render test score`.
+
+### Expected result
+
+- A grand staff with treble and bass clefs appears inside the embedded WebView.
+- The score shows a 4-bar C major, 4/4 example with simple RH and LH material.
+- Tapping `Render test score` again re-renders without crashing.
+
+### Current limitation
+
+`score.html` loads OpenSheetMusicDisplay from a CDN, so the device or emulator needs network access for this milestone.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/assets/score.html
+++ b/app/src/main/assets/score.html
@@ -4,7 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Clefrun Score Renderer</title>
-  <script src="https://cdn.jsdelivr.net/npm/opensheetmusicdisplay@1.9.2/build/opensheetmusicdisplay.min.js"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/opensheetmusicdisplay@1.9.2/build/opensheetmusicdisplay.min.js"
+    integrity="sha384-ayd7AZGRW8a4B990AVWtFlMROQBEIG80Iv+jdk9ejqvApFYdZKlcxhe0PCdVDClg"
+    crossorigin="anonymous"></script>
   <style>
     :root {
       color-scheme: light;

--- a/app/src/main/assets/score.html
+++ b/app/src/main/assets/score.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Clefrun Score Renderer</title>
+  <script src="https://cdn.jsdelivr.net/npm/opensheetmusicdisplay@1.9.2/build/opensheetmusicdisplay.min.js"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #f3efe2;
+      --panel: #fffdf8;
+      --ink: #1f1b16;
+      --line: #d8d0bb;
+      --error: #9f2d20;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at top left, rgba(190, 165, 108, 0.22), transparent 32%),
+        linear-gradient(180deg, #faf6ea 0%, var(--page) 100%);
+      color: var(--ink);
+      font-family: Georgia, "Times New Roman", serif;
+    }
+
+    .shell {
+      min-height: 100vh;
+      padding: 16px;
+    }
+
+    .panel {
+      min-height: calc(100vh - 32px);
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: rgba(255, 253, 248, 0.94);
+      box-shadow: 0 18px 50px rgba(68, 49, 20, 0.10);
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: 20px;
+      font-weight: 600;
+    }
+
+    p {
+      margin: 0 0 16px;
+      color: #5c5244;
+      line-height: 1.4;
+    }
+
+    #status {
+      min-height: 24px;
+      margin-bottom: 12px;
+      font-size: 14px;
+    }
+
+    #status.error {
+      color: var(--error);
+      font-weight: 600;
+    }
+
+    #score {
+      width: 100%;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="panel">
+      <h1>OSMD Test Renderer</h1>
+      <p>Tap the Android button to load the hardcoded MusicXML sample into this WebView.</p>
+      <div id="status">Waiting for MusicXML input.</div>
+      <div id="score"></div>
+    </div>
+  </div>
+  <script>
+    const scoreContainer = document.getElementById("score");
+    const statusNode = document.getElementById("status");
+    let osmd = null;
+
+    function setStatus(message, isError) {
+      statusNode.textContent = message;
+      statusNode.className = isError ? "error" : "";
+    }
+
+    window.renderMusicXml = async function renderMusicXml(xmlString) {
+      try {
+        if (!window.opensheetmusicdisplay || !window.opensheetmusicdisplay.OpenSheetMusicDisplay) {
+          throw new Error("OpenSheetMusicDisplay failed to load. Check network access for the CDN script.");
+        }
+
+        if (!osmd) {
+          osmd = new window.opensheetmusicdisplay.OpenSheetMusicDisplay(scoreContainer, {
+            autoResize: true,
+            drawingParameters: "compacttight"
+          });
+        }
+
+        setStatus("Rendering score...", false);
+        await osmd.load(xmlString);
+        osmd.render();
+        setStatus("Rendered 4-bar test score.", false);
+      } catch (error) {
+        console.error(error);
+        setStatus(error && error.message ? error.message : "Unknown rendering error.", true);
+      }
+    };
+  </script>
+</body>
+</html>

--- a/app/src/main/java/com/clefrun/app/MainActivity.kt
+++ b/app/src/main/java/com/clefrun/app/MainActivity.kt
@@ -75,8 +75,6 @@ private fun ScoreWebView(modifier: Modifier = Modifier) {
         WebView(context).apply {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
-            settings.allowFileAccessFromFileURLs = false
-            settings.allowUniversalAccessFromFileURLs = false
             webViewClient = object : WebViewClient() {
                 override fun shouldOverrideUrlLoading(
                     view: WebView?,

--- a/app/src/main/java/com/clefrun/app/MainActivity.kt
+++ b/app/src/main/java/com/clefrun/app/MainActivity.kt
@@ -1,17 +1,34 @@
 package com.clefrun.app
 
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.clefrun.app.ui.theme.ClefrunTheme
+import org.json.JSONObject
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,9 +37,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             ClefrunTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
+                    ScoreRenderScreen(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
                     )
                 }
             }
@@ -31,17 +49,348 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+fun ScoreRenderScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = "WebView OSMD Render Test")
+        ScoreWebView(
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun ScoreWebView(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var pageLoaded by remember { mutableStateOf(false) }
+    var pendingRender by remember { mutableStateOf(false) }
+    var renderRequests by remember { mutableIntStateOf(0) }
+
+    val webView = remember(context) {
+        WebView(context).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    pageLoaded = true
+                    if (pendingRender) {
+                        pendingRender = false
+                        renderMusicXml(this@apply)
+                    }
+                }
+            }
+            loadUrl(SCORE_HTML_ASSET_URL)
+        }
+    }
+
+    DisposableEffect(webView) {
+        onDispose {
+            webView.destroy()
+        }
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Button(
+            onClick = {
+                renderRequests += 1
+                if (pageLoaded) {
+                    renderMusicXml(webView)
+                } else {
+                    pendingRender = true
+                }
+            }
+        ) {
+            Text("Render test score")
+        }
+
+        AndroidWebView(
+            webView = webView,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        )
+
+        if (renderRequests == 0) {
+            Text(text = "Tap the button to render the hardcoded MusicXML grand staff example.")
+        }
+    }
+}
+
+@Composable
+private fun AndroidWebView(webView: WebView, modifier: Modifier = Modifier) {
+    androidx.compose.ui.viewinterop.AndroidView(
+        factory = { webView },
         modifier = modifier
     )
 }
 
+private fun renderMusicXml(webView: WebView) {
+    val javascript = "window.renderMusicXml(${JSONObject.quote(TEST_GRAND_STAFF_MUSIC_XML)});"
+    webView.evaluateJavascript(javascript, null)
+}
+
+private const val SCORE_HTML_ASSET_URL = "file:///android_asset/score.html"
+
+private const val TEST_GRAND_STAFF_MUSIC_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <backup>
+        <duration>4</duration>
+      </backup>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>2</octave>
+        </pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <backup>
+        <duration>4</duration>
+      </backup>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>2</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+    </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <backup>
+        <duration>4</duration>
+      </backup>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>2</octave>
+        </pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+    </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+      <backup>
+        <duration>4</duration>
+      </backup>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <voice>2</voice>
+        <staff>2</staff>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>
+"""
+
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun ScoreRenderScreenPreview() {
     ClefrunTheme {
-        Greeting("Android")
+        ScoreRenderScreen(
+            modifier = Modifier.height(640.dp)
+        )
     }
 }

--- a/app/src/main/java/com/clefrun/app/MainActivity.kt
+++ b/app/src/main/java/com/clefrun/app/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.clefrun.app
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Bundle
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
@@ -73,7 +75,21 @@ private fun ScoreWebView(modifier: Modifier = Modifier) {
         WebView(context).apply {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
+            settings.allowFileAccessFromFileURLs = false
+            settings.allowUniversalAccessFromFileURLs = false
             webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    return !isAllowedNavigation(request?.url)
+                }
+
+                @Deprecated("Deprecated in Java")
+                override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                    return !isAllowedNavigation(url?.let(Uri::parse))
+                }
+
                 override fun onPageFinished(view: WebView?, url: String?) {
                     pageLoaded = true
                     if (pendingRender) {
@@ -135,10 +151,18 @@ private fun renderMusicXml(webView: WebView) {
     webView.evaluateJavascript(javascript, null)
 }
 
-private const val SCORE_HTML_ASSET_URL = "file:///android_asset/score.html"
+private fun isAllowedNavigation(uri: Uri?): Boolean {
+    if (uri == null) return false
+    val isAsset = uri.toString() == SCORE_HTML_ASSET_URL
+    val isAllowedCdn = uri.scheme == "https" && uri.host == ALLOWED_CDN_HOST
+    val isAboutBlank = uri.toString() == "about:blank"
+    return isAsset || isAllowedCdn || isAboutBlank
+}
 
-private const val TEST_GRAND_STAFF_MUSIC_XML = """
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+private const val SCORE_HTML_ASSET_URL = "file:///android_asset/score.html"
+private const val ALLOWED_CDN_HOST = "cdn.jsdelivr.net"
+
+private const val TEST_GRAND_STAFF_MUSIC_XML = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC
     "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
     "http://www.musicxml.org/dtds/partwise.dtd">
@@ -382,8 +406,7 @@ private const val TEST_GRAND_STAFF_MUSIC_XML = """
       </barline>
     </measure>
   </part>
-</score-partwise>
-"""
+</score-partwise>"""
 
 @Preview(showBackground = true)
 @Composable


### PR DESCRIPTION
## Summary
- add a Compose screen that hosts a WebView and renders a hardcoded MusicXML grand staff sample through a local `score.html` asset
- load OpenSheetMusicDisplay from `score.html`, expose `renderMusicXml(xmlString)`, and document the Milestone 1 smoke test
- add a root CONTRIBUTING guide and ignore local agent/IDE files that should stay private

## Testing
- not run: `./gradlew assembleDebug` (`JAVA_HOME` is not set in this environment)
- not run: `./gradlew test` (`JAVA_HOME` is not set in this environment)`