### PR TITLE
feat: add beginner rule-based generator for milestone 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Clefrun
 
-## Milestone 1 smoke test
+## Milestone 3 smoke test
 
-This milestone proves that Android Compose can host a `WebView`, load `app/src/main/assets/score.html`, and render a hardcoded 4-bar grand staff MusicXML example through OpenSheetMusicDisplay.
+This milestone generates a beginner 4-bar grand staff exercise in `:core`, converts it to MusicXML, and renders it through the existing Android WebView + OpenSheetMusicDisplay pipeline.
 
 ### Run
 
@@ -13,13 +13,13 @@ This milestone proves that Android Compose can host a `WebView`, load `app/src/m
 
 1. Launch the app.
 2. Wait for the `WebView OSMD Render Test` screen to appear.
-3. Tap `Render test score`.
+3. Tap `New exercise`.
 
 ### Expected result
 
 - A grand staff with treble and bass clefs appears inside the embedded WebView.
-- The score shows a 4-bar C major, 4/4 example with simple RH and LH material.
-- Tapping `Render test score` again re-renders without crashing.
+- The score is a generated 4-bar C major, 4/4 beginner exercise with RH melody and LH accompaniment.
+- Tapping `New exercise` again generates and re-renders another deterministic seeded exercise without crashing.
 
 ### Current limitation
 

--- a/app/src/main/java/com/clefrun/app/MainActivity.kt
+++ b/app/src/main/java/com/clefrun/app/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -31,6 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.clefrun.app.ui.theme.ClefrunTheme
 import com.clefrun.core.MusicXmlWriter
+import com.clefrun.core.RuleBasedGenerator
 import org.json.JSONObject
 
 class MainActivity : ComponentActivity() {
@@ -69,8 +71,9 @@ fun ScoreRenderScreen(modifier: Modifier = Modifier) {
 private fun ScoreWebView(modifier: Modifier = Modifier) {
     val context = LocalContext.current
     var pageLoaded by remember { mutableStateOf(false) }
-    var pendingRender by remember { mutableStateOf(false) }
+    var pendingXml by remember { mutableStateOf<String?>(null) }
     var renderRequests by remember { mutableIntStateOf(0) }
+    var seedCounter by remember { mutableLongStateOf(1L) }
 
     val webView = remember(context) {
         WebView(context).apply {
@@ -91,9 +94,9 @@ private fun ScoreWebView(modifier: Modifier = Modifier) {
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     pageLoaded = true
-                    if (pendingRender) {
-                        pendingRender = false
-                        renderMusicXml(this@apply)
+                    pendingXml?.let { xml ->
+                        pendingXml = null
+                        renderMusicXml(this@apply, xml)
                     }
                 }
             }
@@ -113,15 +116,18 @@ private fun ScoreWebView(modifier: Modifier = Modifier) {
     ) {
         Button(
             onClick = {
+                val exercise = RuleBasedGenerator.generate(seedCounter)
+                val xml = MusicXmlWriter.write(exercise)
+                seedCounter += 1
                 renderRequests += 1
                 if (pageLoaded) {
-                    renderMusicXml(webView)
+                    renderMusicXml(webView, xml)
                 } else {
-                    pendingRender = true
+                    pendingXml = xml
                 }
             }
         ) {
-            Text("Render test score")
+            Text("New exercise")
         }
 
         AndroidWebView(
@@ -132,7 +138,7 @@ private fun ScoreWebView(modifier: Modifier = Modifier) {
         )
 
         if (renderRequests == 0) {
-            Text(text = "Tap the button to render the hardcoded MusicXML grand staff example.")
+            Text(text = "Tap the button to generate and render a beginner exercise.")
         }
     }
 }
@@ -145,8 +151,8 @@ private fun AndroidWebView(webView: WebView, modifier: Modifier = Modifier) {
     )
 }
 
-private fun renderMusicXml(webView: WebView) {
-    val javascript = "window.renderMusicXml(${JSONObject.quote(MusicXmlWriter.writeTestExercise())});"
+private fun renderMusicXml(webView: WebView, xmlString: String) {
+    val javascript = "window.renderMusicXml(${JSONObject.quote(xmlString)});"
     webView.evaluateJavascript(javascript, null)
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,3 +14,7 @@ kotlin {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
+
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/core/src/main/kotlin/com/clefrun/core/Domain.kt
+++ b/core/src/main/kotlin/com/clefrun/core/Domain.kt
@@ -9,20 +9,30 @@ data class Exercise(
 
 data class Bar(
     val number: Int,
+    val chord: ChordFunction,
     val rightHand: List<NoteEvent>,
     val leftHand: List<NoteEvent>
 )
 
 data class NoteEvent(
-    val step: String,
-    val octave: Int,
+    val step: String?,
+    val octave: Int?,
     val duration: Duration,
     val staff: Int,
-    val voice: Int
+    val voice: Int,
+    val beatStart: Int,
+    val isRest: Boolean = false
 )
 
-enum class Duration {
-    QUARTER,
-    HALF,
-    WHOLE
+enum class Duration(val beats: Int, val musicXmlType: String) {
+    QUARTER(1, "quarter"),
+    HALF(2, "half"),
+    WHOLE(4, "whole")
+}
+
+enum class ChordFunction {
+    I,
+    IV,
+    V,
+    VI
 }

--- a/core/src/main/kotlin/com/clefrun/core/Domain.kt
+++ b/core/src/main/kotlin/com/clefrun/core/Domain.kt
@@ -22,7 +22,14 @@ data class NoteEvent(
     val voice: Int,
     val beatStart: Int,
     val isRest: Boolean = false
-)
+) {
+    init {
+        if (!isRest) {
+            require(step != null) { "Non-rest NoteEvent must define step." }
+            require(octave != null) { "Non-rest NoteEvent must define octave." }
+        }
+    }
+}
 
 enum class Duration(val beats: Int, val musicXmlType: String) {
     QUARTER(1, "quarter"),

--- a/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
+++ b/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
@@ -2,282 +2,75 @@ package com.clefrun.core
 
 object MusicXmlWriter {
     fun write(exercise: Exercise): String {
-        // Milestone 2 keeps output fixed to the known smoke-test XML.
-        return TEST_EXERCISE_XML
+        val xml = StringBuilder()
+        xml.append("""<?xml version="1.0" encoding="UTF-8" standalone="no"?>""").append('\n')
+        xml.append("<score-partwise version=\"3.1\">").append('\n')
+        xml.append("  <part-list>").append('\n')
+        xml.append("    <score-part id=\"P1\">").append('\n')
+        xml.append("      <part-name>Piano</part-name>").append('\n')
+        xml.append("    </score-part>").append('\n')
+        xml.append("  </part-list>").append('\n')
+        xml.append("  <part id=\"P1\">").append('\n')
+
+        exercise.bars.forEachIndexed { index, bar ->
+            xml.append("    <measure number=\"${bar.number}\">").append('\n')
+
+            if (index == 0) {
+                xml.append("      <attributes>").append('\n')
+                xml.append("        <divisions>1</divisions>").append('\n')
+                xml.append("        <key>").append('\n')
+                xml.append("          <fifths>${exercise.keyFifths}</fifths>").append('\n')
+                xml.append("        </key>").append('\n')
+                xml.append("        <time>").append('\n')
+                xml.append("          <beats>${exercise.beats}</beats>").append('\n')
+                xml.append("          <beat-type>${exercise.beatType}</beat-type>").append('\n')
+                xml.append("        </time>").append('\n')
+                xml.append("        <staves>2</staves>").append('\n')
+                xml.append("        <clef number=\"1\">").append('\n')
+                xml.append("          <sign>G</sign>").append('\n')
+                xml.append("          <line>2</line>").append('\n')
+                xml.append("        </clef>").append('\n')
+                xml.append("        <clef number=\"2\">").append('\n')
+                xml.append("          <sign>F</sign>").append('\n')
+                xml.append("          <line>4</line>").append('\n')
+                xml.append("        </clef>").append('\n')
+                xml.append("      </attributes>").append('\n')
+            }
+
+            bar.rightHand.forEach { note -> appendNote(xml, note) }
+            xml.append("      <backup>").append('\n')
+            xml.append("        <duration>${exercise.beats}</duration>").append('\n')
+            xml.append("      </backup>").append('\n')
+            bar.leftHand.forEach { note -> appendNote(xml, note) }
+
+            if (index == exercise.bars.lastIndex) {
+                xml.append("      <barline location=\"right\">").append('\n')
+                xml.append("        <bar-style>light-heavy</bar-style>").append('\n')
+                xml.append("      </barline>").append('\n')
+            }
+
+            xml.append("    </measure>").append('\n')
+        }
+
+        xml.append("  </part>").append('\n')
+        xml.append("</score-partwise>")
+        return xml.toString()
     }
 
-    fun writeTestExercise(): String {
-        return write(
-            exercise = Exercise(
-                bars = listOf(
-                    Bar(
-                        number = 1,
-                        rightHand = emptyList(),
-                        leftHand = emptyList()
-                    ),
-                    Bar(
-                        number = 2,
-                        rightHand = emptyList(),
-                        leftHand = emptyList()
-                    ),
-                    Bar(
-                        number = 3,
-                        rightHand = emptyList(),
-                        leftHand = emptyList()
-                    ),
-                    Bar(
-                        number = 4,
-                        rightHand = emptyList(),
-                        leftHand = emptyList()
-                    )
-                )
-            )
-        )
+    private fun appendNote(xml: StringBuilder, note: NoteEvent) {
+        xml.append("      <note>").append('\n')
+        if (note.isRest) {
+            xml.append("        <rest/>").append('\n')
+        } else {
+            xml.append("        <pitch>").append('\n')
+            xml.append("          <step>${note.step}</step>").append('\n')
+            xml.append("          <octave>${note.octave}</octave>").append('\n')
+            xml.append("        </pitch>").append('\n')
+        }
+        xml.append("        <duration>${note.duration.beats}</duration>").append('\n')
+        xml.append("        <type>${note.duration.musicXmlType}</type>").append('\n')
+        xml.append("        <voice>${note.voice}</voice>").append('\n')
+        xml.append("        <staff>${note.staff}</staff>").append('\n')
+        xml.append("      </note>").append('\n')
     }
 }
-
-private const val TEST_EXERCISE_XML = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE score-partwise PUBLIC
-    "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
-    "http://www.musicxml.org/dtds/partwise.dtd">
-<score-partwise version="3.1">
-  <part-list>
-    <score-part id="P1">
-      <part-name>Piano</part-name>
-    </score-part>
-  </part-list>
-  <part id="P1">
-    <measure number="1">
-      <attributes>
-        <divisions>1</divisions>
-        <key>
-          <fifths>0</fifths>
-        </key>
-        <time>
-          <beats>4</beats>
-          <beat-type>4</beat-type>
-        </time>
-        <staves>2</staves>
-        <clef number="1">
-          <sign>G</sign>
-          <line>2</line>
-        </clef>
-        <clef number="2">
-          <sign>F</sign>
-          <line>4</line>
-        </clef>
-      </attributes>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <backup>
-        <duration>4</duration>
-      </backup>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>3</octave>
-        </pitch>
-        <duration>2</duration>
-        <type>half</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>2</octave>
-        </pitch>
-        <duration>2</duration>
-        <type>half</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-    </measure>
-    <measure number="2">
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>F</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <backup>
-        <duration>4</duration>
-      </backup>
-      <note>
-        <pitch>
-          <step>F</step>
-          <octave>2</octave>
-        </pitch>
-        <duration>4</duration>
-        <type>whole</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-    </measure>
-    <measure number="3">
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>1</duration>
-        <type>quarter</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <backup>
-        <duration>4</duration>
-      </backup>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>2</octave>
-        </pitch>
-        <duration>2</duration>
-        <type>half</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>3</octave>
-        </pitch>
-        <duration>2</duration>
-        <type>half</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-    </measure>
-    <measure number="4">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-        </pitch>
-        <duration>4</duration>
-        <type>whole</type>
-        <voice>1</voice>
-        <staff>1</staff>
-      </note>
-      <backup>
-        <duration>4</duration>
-      </backup>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>3</octave>
-        </pitch>
-        <duration>4</duration>
-        <type>whole</type>
-        <voice>2</voice>
-        <staff>2</staff>
-      </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-      </barline>
-    </measure>
-  </part>
-</score-partwise>"""

--- a/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
+++ b/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
@@ -62,9 +62,11 @@ object MusicXmlWriter {
         if (note.isRest) {
             xml.append("        <rest/>").append('\n')
         } else {
+            val step = requireNotNull(note.step) { "Non-rest note must include step." }
+            val octave = requireNotNull(note.octave) { "Non-rest note must include octave." }
             xml.append("        <pitch>").append('\n')
-            xml.append("          <step>${note.step}</step>").append('\n')
-            xml.append("          <octave>${note.octave}</octave>").append('\n')
+            xml.append("          <step>$step</step>").append('\n')
+            xml.append("          <octave>$octave</octave>").append('\n')
             xml.append("        </pitch>").append('\n')
         }
         xml.append("        <duration>${note.duration.beats}</duration>").append('\n')

--- a/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
+++ b/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
@@ -185,18 +185,13 @@ private fun noteFromMidi(
 private fun midiToStepOctave(midi: Int): Pair<String, Int> {
     val step = when (pitchClass(midi)) {
         0 -> "C"
-        1 -> "C"
         2 -> "D"
-        3 -> "D"
         4 -> "E"
         5 -> "F"
-        6 -> "F"
         7 -> "G"
-        8 -> "G"
         9 -> "A"
-        10 -> "A"
         11 -> "B"
-        else -> error("Unexpected pitch class")
+        else -> error("Accidental pitch class ${pitchClass(midi)} is not supported in M3 writer.")
     }
     val octave = (midi / 12) - 1
     return step to octave

--- a/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
+++ b/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
@@ -1,0 +1,205 @@
+package com.clefrun.core
+
+import kotlin.math.abs
+import kotlin.random.Random
+
+object RuleBasedGenerator {
+    fun generate(seed: Long): Exercise {
+        val random = Random(seed)
+        val chords = listOf(
+            randomEarlyChord(random),
+            randomEarlyChord(random),
+            if (random.nextDouble() < 0.85) ChordFunction.V else randomEarlyChord(random),
+            ChordFunction.I
+        )
+
+        var previousRhMidi: Int? = null
+        var usedPerfectFifth = false
+
+        val bars = chords.mapIndexed { index, chord ->
+            val rhythms = rightHandRhythmPattern(random)
+            val rightHand = mutableListOf<NoteEvent>()
+            var beat = 1
+            for (duration in rhythms) {
+                val mustBeChordTone = beat == 1 || beat == 3
+                val midi = chooseRightHandMidi(
+                    random = random,
+                    chord = chord,
+                    previousMidi = previousRhMidi,
+                    mustBeChordTone = mustBeChordTone,
+                    canUsePerfectFifth = !usedPerfectFifth
+                )
+                if (previousRhMidi != null && abs(midi - previousRhMidi) == 7) {
+                    usedPerfectFifth = true
+                }
+                previousRhMidi = midi
+
+                val (step, octave) = midiToStepOctave(midi)
+                rightHand += NoteEvent(
+                    step = step,
+                    octave = octave,
+                    duration = duration,
+                    staff = 1,
+                    voice = 1,
+                    beatStart = beat
+                )
+                beat += duration.beats
+            }
+
+            Bar(
+                number = index + 1,
+                chord = chord,
+                rightHand = rightHand,
+                leftHand = generateLeftHand(random, chord)
+            )
+        }
+
+        return Exercise(bars = bars)
+    }
+}
+
+private fun randomEarlyChord(random: Random): ChordFunction {
+    val pool = listOf(ChordFunction.I, ChordFunction.IV, ChordFunction.V, ChordFunction.VI)
+    return pool[random.nextInt(pool.size)]
+}
+
+private fun rightHandRhythmPattern(random: Random): List<Duration> {
+    val patterns = listOf(
+        listOf(Duration.QUARTER, Duration.QUARTER, Duration.QUARTER, Duration.QUARTER),
+        listOf(Duration.HALF, Duration.HALF),
+        listOf(Duration.QUARTER, Duration.QUARTER, Duration.HALF),
+        listOf(Duration.HALF, Duration.QUARTER, Duration.QUARTER)
+    )
+    return patterns[random.nextInt(patterns.size)]
+}
+
+private fun generateLeftHand(random: Random, chord: ChordFunction): List<NoteEvent> {
+    val rootMidi = leftHandRootMidi(chord)
+    val fifthMidi = leftHandFifthMidi(chord)
+    val useFifthOnBeatThree = random.nextBoolean()
+
+    return listOf(
+        noteFromMidi(rootMidi, Duration.HALF, staff = 2, voice = 2, beatStart = 1),
+        noteFromMidi(
+            if (useFifthOnBeatThree) fifthMidi else rootMidi,
+            Duration.HALF,
+            staff = 2,
+            voice = 2,
+            beatStart = 3
+        )
+    )
+}
+
+private fun chooseRightHandMidi(
+    random: Random,
+    chord: ChordFunction,
+    previousMidi: Int?,
+    mustBeChordTone: Boolean,
+    canUsePerfectFifth: Boolean
+): Int {
+    val candidates = rightHandRange().filter { midi ->
+        isCmajor(midi) && (!mustBeChordTone || isChordTone(midi, chord))
+    }
+
+    if (previousMidi == null) {
+        val preferred = candidates.filter { it in 64..72 }
+        val pool = if (preferred.isNotEmpty()) preferred else candidates
+        return pool[random.nextInt(pool.size)]
+    }
+
+    val allowed = candidates.filter { midi ->
+        val diff = abs(midi - previousMidi)
+        diff <= 5 || (diff == 7 && canUsePerfectFifth)
+    }
+    val pool = if (allowed.isNotEmpty()) {
+        allowed
+    } else {
+        val nearest = candidates.minBy { abs(it - previousMidi) }
+        listOf(nearest)
+    }
+
+    val weighted = pool
+        .map { midi ->
+            val diff = abs(midi - previousMidi)
+            val weight = when {
+                diff <= 1 -> 7
+                diff <= 2 -> 5
+                diff <= 4 -> 2
+                diff == 5 -> 1
+                diff == 7 -> 1
+                else -> 1
+            }
+            midi to weight
+        }
+        .flatMap { (midi, weight) -> List(weight) { midi } }
+
+    return weighted[random.nextInt(weighted.size)]
+}
+
+private fun rightHandRange(): IntRange = 60..79 // C4..G5
+
+private fun isCmajor(midi: Int): Boolean = pitchClass(midi) in setOf(0, 2, 4, 5, 7, 9, 11)
+
+private fun isChordTone(midi: Int, chord: ChordFunction): Boolean {
+    val tones = when (chord) {
+        ChordFunction.I -> setOf(0, 4, 7)
+        ChordFunction.IV -> setOf(5, 9, 0)
+        ChordFunction.V -> setOf(7, 11, 2)
+        ChordFunction.VI -> setOf(9, 0, 4)
+    }
+    return pitchClass(midi) in tones
+}
+
+private fun leftHandRootMidi(chord: ChordFunction): Int {
+    // C2..C3 preferred low register
+    return when (chord) {
+        ChordFunction.I -> 36  // C2
+        ChordFunction.IV -> 41 // F2
+        ChordFunction.V -> 43  // G2
+        ChordFunction.VI -> 45 // A2
+    }
+}
+
+private fun leftHandFifthMidi(chord: ChordFunction): Int {
+    return leftHandRootMidi(chord) + 7
+}
+
+private fun noteFromMidi(
+    midi: Int,
+    duration: Duration,
+    staff: Int,
+    voice: Int,
+    beatStart: Int
+): NoteEvent {
+    val (step, octave) = midiToStepOctave(midi)
+    return NoteEvent(
+        step = step,
+        octave = octave,
+        duration = duration,
+        staff = staff,
+        voice = voice,
+        beatStart = beatStart
+    )
+}
+
+private fun midiToStepOctave(midi: Int): Pair<String, Int> {
+    val step = when (pitchClass(midi)) {
+        0 -> "C"
+        1 -> "C"
+        2 -> "D"
+        3 -> "D"
+        4 -> "E"
+        5 -> "F"
+        6 -> "F"
+        7 -> "G"
+        8 -> "G"
+        9 -> "A"
+        10 -> "A"
+        11 -> "B"
+        else -> error("Unexpected pitch class")
+    }
+    val octave = (midi / 12) - 1
+    return step to octave
+}
+
+private fun pitchClass(midi: Int): Int = ((midi % 12) + 12) % 12

--- a/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
+++ b/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
@@ -1,0 +1,65 @@
+package com.clefrun.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuleBasedGeneratorTest {
+    @Test
+    fun generatedExerciseHas4Bars() {
+        val exercise = RuleBasedGenerator.generate(seed = 42L)
+        assertEquals(4, exercise.bars.size)
+    }
+
+    @Test
+    fun eachBarSumsTo4Beats() {
+        val seeds = listOf(1L, 2L, 42L, 100L)
+        seeds.forEach { seed ->
+            val exercise = RuleBasedGenerator.generate(seed)
+            exercise.bars.forEach { bar ->
+                assertEquals(4, bar.rightHand.sumOf { it.duration.beats })
+                assertEquals(4, bar.leftHand.sumOf { it.duration.beats })
+            }
+        }
+    }
+
+    @Test
+    fun rightHandBeats1And3AreChordTones() {
+        val seeds = listOf(3L, 8L, 21L, 55L)
+        seeds.forEach { seed ->
+            val exercise = RuleBasedGenerator.generate(seed)
+            exercise.bars.forEach { bar ->
+                val beat1 = bar.rightHand.firstOrNull { it.beatStart == 1 && !it.isRest }
+                val beat3 = bar.rightHand.firstOrNull { it.beatStart == 3 && !it.isRest }
+                assertTrue("Missing RH note on beat 1 for bar ${bar.number}", beat1 != null)
+                assertTrue("Missing RH note on beat 3 for bar ${bar.number}", beat3 != null)
+                assertTrue(isChordTone(beat1!!, bar.chord))
+                assertTrue(isChordTone(beat3!!, bar.chord))
+            }
+        }
+    }
+
+    private fun isChordTone(note: NoteEvent, chord: ChordFunction): Boolean {
+        val pitchClass = stepToPitchClass(note.step ?: return false)
+        val tones = when (chord) {
+            ChordFunction.I -> setOf(0, 4, 7)
+            ChordFunction.IV -> setOf(5, 9, 0)
+            ChordFunction.V -> setOf(7, 11, 2)
+            ChordFunction.VI -> setOf(9, 0, 4)
+        }
+        return pitchClass in tones
+    }
+
+    private fun stepToPitchClass(step: String): Int {
+        return when (step) {
+            "C" -> 0
+            "D" -> 2
+            "E" -> 4
+            "F" -> 5
+            "G" -> 7
+            "A" -> 9
+            "B" -> 11
+            else -> error("Unexpected step $step")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RuleBasedGenerator` in `:core` to generate deterministic seeded 4-bar beginner exercises in C major, 4/4, grand staff
- update `MusicXmlWriter` to serialize generated `Exercise` data to MusicXML instead of returning fixed XML
- update `:app` button flow to generate and render a new exercise each tap while keeping the existing WebView/OSMD pipeline behavior unchanged
- add core unit tests for bar count, per-bar beat totals, and RH chord-tone checks on beats 1 and 3

## Validation
- `./gradlew assembleDebug`
- `./gradlew test`