### PR TITLE
feat(core): add difficulty-aware 8-bar generation

### DIFF
--- a/app/src/main/java/com/clefrun/app/MainActivity.kt
+++ b/app/src/main/java/com/clefrun/app/MainActivity.kt
@@ -74,6 +74,7 @@ import com.clefrun.app.ui.theme.Stroke
 import com.clefrun.app.ui.theme.TextPrimary
 import com.clefrun.app.ui.theme.TextSecondary
 import com.clefrun.app.ui.theme.WarmAccent
+import com.clefrun.core.Difficulty
 import com.clefrun.core.MusicXmlWriter
 import com.clefrun.core.RuleBasedGenerator
 import kotlinx.coroutines.launch
@@ -101,12 +102,19 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun ScoreWebView(
     regenerateSignal: Long,
+    difficulty: Difficulty,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     var pageLoaded by remember { mutableStateOf(false) }
     var seedCounter by remember { mutableLongStateOf(2L) }
-    var pendingXml by remember { mutableStateOf<String?>(generateExerciseXml(1L)) }
+    var pendingXml by remember { mutableStateOf<String?>(generateExerciseXml(1L, difficulty)) }
+
+    LaunchedEffect(difficulty, pageLoaded) {
+        if (!pageLoaded) {
+            pendingXml = generateExerciseXml(1L, difficulty)
+        }
+    }
 
     val webView = remember(context) {
         WebView(context).apply {
@@ -145,7 +153,7 @@ private fun ScoreWebView(
 
     LaunchedEffect(regenerateSignal) {
         if (regenerateSignal == 0L) return@LaunchedEffect
-        val xml = generateExerciseXml(seedCounter)
+        val xml = generateExerciseXml(seedCounter, difficulty)
         seedCounter += 1
         if (pageLoaded) {
             renderMusicXml(webView, xml)
@@ -168,8 +176,8 @@ private fun ScoreWebView(
     }
 }
 
-private fun generateExerciseXml(seed: Long): String {
-    val exercise = RuleBasedGenerator.generate(seed)
+private fun generateExerciseXml(seed: Long, difficulty: Difficulty): String {
+    val exercise = RuleBasedGenerator.generate(seed, difficulty)
     return MusicXmlWriter.write(exercise)
 }
 
@@ -196,7 +204,7 @@ fun ScoreRenderScreen(
     onRegenerate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedDifficulty by remember { mutableStateOf(DifficultyUi.EASY) }
+    var selectedDifficulty by remember { mutableStateOf(Difficulty.EASY) }
     var tempo by remember { mutableFloatStateOf(0.55f) }
 
     val scaffoldState = rememberBottomSheetScaffoldState(
@@ -241,7 +249,7 @@ fun ScoreRenderScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(AppBackground)
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
         ) {
             TopOverlayBar(
                 onNewClick = onRegenerate,
@@ -268,6 +276,7 @@ fun ScoreRenderScreen(
             ) {
                 ScoreWebView(
                     regenerateSignal = regenerateSignal,
+                    difficulty = selectedDifficulty,
                     modifier = Modifier.fillMaxSize()
                 )
             }
@@ -383,8 +392,8 @@ private fun OptionsButton(
 
 @Composable
 private fun OptionsSheetContent(
-    selectedDifficulty: DifficultyUi,
-    onDifficultySelected: (DifficultyUi) -> Unit,
+    selectedDifficulty: Difficulty,
+    onDifficultySelected: (Difficulty) -> Unit,
     tempo: Float,
     onTempoChange: (Float) -> Unit,
     modifier: Modifier = Modifier,
@@ -445,7 +454,7 @@ private fun OptionsSheetContent(
                 )
 
                 Text(
-                    text = "Difficulty and tempo controls are preview-only for now.",
+                    text = "Tempo is preview-only for now.",
                     color = TextSecondary,
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(top = 8.dp)
@@ -459,12 +468,11 @@ private fun OptionsSheetContent(
 
 @Composable
 private fun DifficultySelector(
-    selected: DifficultyUi,
-    onSelected: (DifficultyUi) -> Unit,
+    selected: Difficulty,
+    onSelected: (Difficulty) -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
 ) {
-    val options = DifficultyUi.entries
+    val options = Difficulty.entries
 
     SingleChoiceSegmentedButtonRow(
         modifier = modifier.fillMaxWidth()
@@ -473,7 +481,6 @@ private fun DifficultySelector(
             SegmentedButton(
                 selected = selected == option,
                 onClick = { onSelected(option) },
-                enabled = enabled,
                 shape = SegmentedButtonDefaults.itemShape(
                     index = index,
                     count = options.size
@@ -497,12 +504,6 @@ private fun DifficultySelector(
     }
 }
 
-private enum class DifficultyUi(val label: String) {
-    EASY("Easy"),
-    MEDIUM("Medium"),
-    HARD("Liszt"),
-}
-
 @Composable
 private fun AndroidWebView(webView: WebView, modifier: Modifier = Modifier) {
     androidx.compose.ui.viewinterop.AndroidView(
@@ -510,3 +511,10 @@ private fun AndroidWebView(webView: WebView, modifier: Modifier = Modifier) {
         modifier = modifier
     )
 }
+
+private val Difficulty.label: String
+    get() = when (this) {
+        Difficulty.EASY -> "Easy"
+        Difficulty.MEDIUM -> "Medium"
+        Difficulty.HARD -> "Hard"
+    }

--- a/core/src/main/kotlin/com/clefrun/core/Domain.kt
+++ b/core/src/main/kotlin/com/clefrun/core/Domain.kt
@@ -7,6 +7,12 @@ data class Exercise(
     val keyFifths: Int = 0
 )
 
+enum class Difficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}
+
 data class Bar(
     val number: Int,
     val chord: ChordFunction,

--- a/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
+++ b/core/src/main/kotlin/com/clefrun/core/MusicXmlWriter.kt
@@ -13,6 +13,7 @@ object MusicXmlWriter {
         xml.append("  <part id=\"P1\">").append('\n')
 
         exercise.bars.forEachIndexed { index, bar ->
+            val accidentalStateByPitch = mutableMapOf<AccidentalKey, Int>()
             xml.append("    <measure number=\"${bar.number}\">").append('\n')
 
             if (index == 0) {
@@ -37,11 +38,11 @@ object MusicXmlWriter {
                 xml.append("      </attributes>").append('\n')
             }
 
-            bar.rightHand.forEach { note -> appendNote(xml, note) }
+            bar.rightHand.forEach { note -> appendNote(xml, note, accidentalStateByPitch) }
             xml.append("      <backup>").append('\n')
             xml.append("        <duration>${exercise.beats}</duration>").append('\n')
             xml.append("      </backup>").append('\n')
-            bar.leftHand.forEach { note -> appendNote(xml, note) }
+            bar.leftHand.forEach { note -> appendNote(xml, note, accidentalStateByPitch) }
 
             if (index == exercise.bars.lastIndex) {
                 xml.append("      <barline location=\"right\">").append('\n')
@@ -57,21 +58,34 @@ object MusicXmlWriter {
         return xml.toString()
     }
 
-    private fun appendNote(xml: StringBuilder, note: NoteEvent) {
+    private fun appendNote(
+        xml: StringBuilder,
+        note: NoteEvent,
+        accidentalStateByPitch: MutableMap<AccidentalKey, Int>
+    ) {
         xml.append("      <note>").append('\n')
         var accidental: String? = null
         if (note.isRest) {
             xml.append("        <rest/>").append('\n')
         } else {
             val pitch = requireNotNull(note.pitch) { "Non-rest note must include pitch." }
+            val accidentalKey = AccidentalKey(
+                step = pitch.step,
+                octave = pitch.octave,
+                staff = note.staff
+            )
+            accidental = accidentalSymbolForDisplay(
+                currentAlter = pitch.alter,
+                previousAlter = accidentalStateByPitch[accidentalKey]
+            )
+
             xml.append("        <pitch>").append('\n')
             xml.append("          <step>${pitch.step.name}</step>").append('\n')
             xml.append("          <alter>${pitch.alter}</alter>").append('\n')
             xml.append("          <octave>${pitch.octave}</octave>").append('\n')
             xml.append("        </pitch>").append('\n')
-            if (pitch.alter != 0) {
-                accidental = if (pitch.alter > 0) "sharp" else "flat"
-            }
+
+            accidentalStateByPitch[accidentalKey] = pitch.alter
         }
         xml.append("        <duration>${note.duration.beats}</duration>").append('\n')
         xml.append("        <type>${note.duration.musicXmlType}</type>").append('\n')
@@ -82,4 +96,20 @@ object MusicXmlWriter {
         xml.append("        <staff>${note.staff}</staff>").append('\n')
         xml.append("      </note>").append('\n')
     }
+
+    private fun accidentalSymbolForDisplay(currentAlter: Int, previousAlter: Int?): String? {
+        if (previousAlter == currentAlter) return null
+        return when (currentAlter) {
+            1 -> "sharp"
+            -1 -> "flat"
+            0 -> if (previousAlter == null) null else "natural"
+            else -> error("Unexpected alter value: $currentAlter")
+        }
+    }
 }
+
+private data class AccidentalKey(
+    val step: Step,
+    val octave: Int,
+    val staff: Int
+)

--- a/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
+++ b/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
@@ -4,12 +4,12 @@ import kotlin.math.abs
 import kotlin.random.Random
 
 object RuleBasedGenerator {
-    fun generate(seed: Long): Exercise {
+    fun generate(seed: Long, difficulty: Difficulty = Difficulty.MEDIUM): Exercise {
         val random = Random(seed)
+        val profile = difficulty.profile()
         val chords = buildChordProgression(random)
 
         var previousRhMidi: Int? = null
-        var usedPerfectFifth = false
         var previousShape: List<Int>? = null
         var recentRhMidis: List<Int> = emptyList()
 
@@ -19,26 +19,23 @@ object RuleBasedGenerator {
                 random = random,
                 chord = chord,
                 previousRhMidi = previousRhMidi,
-                usedPerfectFifth = usedPerfectFifth,
                 previousShape = previousShape,
-                globalRecentMidis = recentRhMidis
+                globalRecentMidis = recentRhMidis,
+                profile = profile
             )
 
-            maybeInsertChromaticApproach(random = random, chord = chord, rightHand = rightHand)
+            maybeInsertChromaticApproach(
+                random = random,
+                chord = chord,
+                rightHand = rightHand,
+                profile = profile
+            )
 
             if (rightHand.size > 1) {
                 previousShape = rightHand.zipWithNext { a, b -> b.midi - a.midi }
             }
-
-            if (rightHand.size >= 2) {
-                for (i in 1 until rightHand.size) {
-                    if (abs(rightHand[i].midi - rightHand[i - 1].midi) == 7) {
-                        usedPerfectFifth = true
-                    }
-                }
-            }
             previousRhMidi = rightHand.lastOrNull()?.midi ?: previousRhMidi
-            recentRhMidis = (recentRhMidis + rightHand.map { it.midi }).takeLast(2)
+            recentRhMidis = (recentRhMidis + rightHand.map { it.midi }).takeLast(3)
 
             bars += Bar(
                 number = index + 1,
@@ -52,12 +49,29 @@ object RuleBasedGenerator {
                         beatStart = it.beatStart
                     )
                 },
-                leftHand = generateLeftHand(random, chord)
+                leftHand = generateLeftHand(random, chord, profile)
             )
         }
 
         return Exercise(bars = bars)
     }
+}
+
+private data class DifficultyProfile(
+    val rightHandRange: IntRange,
+    val preferredOpeningRange: IntRange,
+    val rhythmPatterns: List<List<Duration>>,
+    val accidentalProbability: Double,
+    val maxLeap: Int,
+    val largeLeapWeightPenalty: Int,
+    val repeatPenalty: Int,
+    val leftHandStyle: LeftHandStyle
+)
+
+private enum class LeftHandStyle {
+    EASY,
+    MEDIUM,
+    HARD
 }
 
 private data class MutableRhEvent(
@@ -66,17 +80,89 @@ private data class MutableRhEvent(
     val beatStart: Int
 )
 
+private fun Difficulty.profile(): DifficultyProfile {
+    return when (this) {
+        Difficulty.EASY -> DifficultyProfile(
+            rightHandRange = 62..74,
+            preferredOpeningRange = 65..71,
+            rhythmPatterns = listOf(
+                listOf(Duration.HALF, Duration.HALF),
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.HALF),
+                listOf(Duration.HALF, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.HALF, Duration.HALF)
+            ),
+            accidentalProbability = 0.0,
+            maxLeap = 5,
+            largeLeapWeightPenalty = 3,
+            repeatPenalty = 4,
+            leftHandStyle = LeftHandStyle.EASY
+        )
+        Difficulty.MEDIUM -> DifficultyProfile(
+            rightHandRange = 60..79,
+            preferredOpeningRange = 64..72,
+            rhythmPatterns = listOf(
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.HALF),
+                listOf(Duration.HALF, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.QUARTER, Duration.HALF, Duration.QUARTER),
+                listOf(Duration.HALF, Duration.HALF)
+            ),
+            accidentalProbability = 0.18,
+            maxLeap = 7,
+            largeLeapWeightPenalty = 2,
+            repeatPenalty = 3,
+            leftHandStyle = LeftHandStyle.MEDIUM
+        )
+        Difficulty.HARD -> DifficultyProfile(
+            rightHandRange = 59..81,
+            preferredOpeningRange = 63..74,
+            rhythmPatterns = listOf(
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.QUARTER, Duration.QUARTER, Duration.HALF),
+                listOf(Duration.HALF, Duration.QUARTER, Duration.QUARTER),
+                listOf(Duration.QUARTER, Duration.HALF, Duration.QUARTER)
+            ),
+            accidentalProbability = 0.35,
+            maxLeap = 9,
+            largeLeapWeightPenalty = 1,
+            repeatPenalty = 2,
+            leftHandStyle = LeftHandStyle.HARD
+        )
+    }
+}
+
 private fun buildChordProgression(random: Random): List<ChordFunction> {
-    val openingPool = listOf(ChordFunction.I, ChordFunction.II, ChordFunction.III, ChordFunction.IV, ChordFunction.VI)
+    val phraseA = buildPhrase(random)
+    val phraseB = buildPhrase(random, avoidOpenings = setOf(phraseA.first(), phraseA.last()))
+    return phraseA + phraseB
+}
+
+private fun buildPhrase(
+    random: Random,
+    avoidOpenings: Set<ChordFunction> = emptySet()
+): List<ChordFunction> {
+    val openingPool = listOf(
+        ChordFunction.I,
+        ChordFunction.II,
+        ChordFunction.III,
+        ChordFunction.IV,
+        ChordFunction.VI
+    ).filterNot { it in avoidOpenings }
     val bar1 = openingPool[random.nextInt(openingPool.size)]
 
-    val bar2Pool = listOf(ChordFunction.II, ChordFunction.III, ChordFunction.IV, ChordFunction.V, ChordFunction.VI)
-        .filter { it != bar1 }
+    val bar2Pool = listOf(
+        ChordFunction.II,
+        ChordFunction.III,
+        ChordFunction.IV,
+        ChordFunction.V,
+        ChordFunction.VI
+    ).filter { it != bar1 }
     val bar2 = bar2Pool[random.nextInt(bar2Pool.size)]
 
     val bar3Pool = listOf(ChordFunction.V, ChordFunction.II, ChordFunction.IV)
         .filter { it != bar2 }
-    val bar3 = if (random.nextDouble() < 0.80 && bar2 != ChordFunction.V) {
+    val bar3 = if (random.nextDouble() < 0.75 && bar2 != ChordFunction.V) {
         ChordFunction.V
     } else {
         bar3Pool[random.nextInt(bar3Pool.size)]
@@ -89,34 +175,29 @@ private fun generateRightHandBar(
     random: Random,
     chord: ChordFunction,
     previousRhMidi: Int?,
-    usedPerfectFifth: Boolean,
     previousShape: List<Int>?,
-    globalRecentMidis: List<Int>
+    globalRecentMidis: List<Int>,
+    profile: DifficultyProfile
 ): MutableList<MutableRhEvent> {
-    val rhythms = rightHandRhythmPattern(random)
     var attempt = 0
     while (true) {
+        val rhythms = rightHandRhythmPattern(random, profile)
         val events = mutableListOf<MutableRhEvent>()
         var beat = 1
         var localPrev = previousRhMidi
-        var localUsedPerfectFifth = usedPerfectFifth
         val contourDirection = if (random.nextBoolean()) 1 else -1
 
         for (duration in rhythms) {
-            val mustBeChordTone = beat == 1 || beat == 3
             val midi = chooseRightHandMidi(
                 random = random,
                 chord = chord,
                 previousMidi = localPrev,
-                mustBeChordTone = mustBeChordTone,
-                canUsePerfectFifth = !localUsedPerfectFifth,
+                mustBeChordTone = beat == 1 || beat == 3,
                 contourDirection = contourDirection,
                 weakBeat = beat == 2 || beat == 4,
-                recent = (globalRecentMidis + events.takeLast(2).map { it.midi }).takeLast(2)
+                recent = (globalRecentMidis + events.takeLast(2).map { it.midi }).takeLast(3),
+                profile = profile
             )
-            if (localPrev != null && abs(midi - localPrev) == 7) {
-                localUsedPerfectFifth = true
-            }
             events += MutableRhEvent(midi = midi, duration = duration, beatStart = beat)
             localPrev = midi
             beat += duration.beats
@@ -134,67 +215,105 @@ private fun generateRightHandBar(
 private fun maybeInsertChromaticApproach(
     random: Random,
     chord: ChordFunction,
-    rightHand: MutableList<MutableRhEvent>
+    rightHand: MutableList<MutableRhEvent>,
+    profile: DifficultyProfile
 ) {
-    if (random.nextDouble() >= 0.20) return
+    if (profile.accidentalProbability <= 0.0 || random.nextDouble() >= profile.accidentalProbability) {
+        return
+    }
 
     val eligibleIndices = rightHand.indices.filter { index ->
         val event = rightHand[index]
-        val hasNext = index + 1 < rightHand.size
-        if (!hasNext) return@filter false
-
-        val weakBeat = event.beatStart == 2 || event.beatStart == 4
-        if (!weakBeat) return@filter false
+        if (index + 1 >= rightHand.size) return@filter false
+        if (event.beatStart != 2 && event.beatStart != 4) return@filter false
 
         val targetMidi = rightHand[index + 1].midi
-        if (!isChordTone(targetMidi, chord) || !isCmajor(targetMidi)) return@filter false
-
-        chromaticApproachCandidates(targetMidi).isNotEmpty()
+        isChordTone(targetMidi, chord) &&
+            isCmajor(targetMidi) &&
+            chromaticApproachCandidates(targetMidi, profile.rightHandRange).isNotEmpty()
     }
 
     if (eligibleIndices.isEmpty()) return
+
     val index = eligibleIndices[random.nextInt(eligibleIndices.size)]
     val targetMidi = rightHand[index + 1].midi
-    val candidates = chromaticApproachCandidates(targetMidi)
+    val candidates = chromaticApproachCandidates(targetMidi, profile.rightHandRange)
     rightHand[index].midi = candidates[random.nextInt(candidates.size)]
 }
 
-private fun chromaticApproachCandidates(targetMidi: Int): List<Int> {
-    val candidates = listOf(targetMidi - 1, targetMidi + 1)
-    return candidates.filter { midi ->
-        midi in rightHandRange() && isAccidentalPitchClass(pitchClass(midi))
+private fun chromaticApproachCandidates(targetMidi: Int, range: IntRange): List<Int> {
+    return listOf(targetMidi - 1, targetMidi + 1).filter { midi ->
+        midi in range && isAccidentalPitchClass(pitchClass(midi))
     }
 }
 
-private fun isAccidentalPitchClass(pitchClass: Int): Boolean {
-    return pitchClass in setOf(1, 3, 6, 8, 10)
+private fun rightHandRhythmPattern(random: Random, profile: DifficultyProfile): List<Duration> {
+    return profile.rhythmPatterns[random.nextInt(profile.rhythmPatterns.size)]
 }
 
-private fun rightHandRhythmPattern(random: Random): List<Duration> {
-    val patterns = listOf(
-        listOf(Duration.QUARTER, Duration.QUARTER, Duration.QUARTER, Duration.QUARTER),
-        listOf(Duration.HALF, Duration.HALF),
-        listOf(Duration.QUARTER, Duration.QUARTER, Duration.HALF),
-        listOf(Duration.HALF, Duration.QUARTER, Duration.QUARTER)
-    )
-    return patterns[random.nextInt(patterns.size)]
-}
+private fun generateLeftHand(
+    random: Random,
+    chord: ChordFunction,
+    profile: DifficultyProfile
+): List<NoteEvent> {
+    val root = leftHandRootMidi(chord)
+    val third = leftHandThirdMidi(chord)
+    val fifth = leftHandFifthMidi(chord)
 
-private fun generateLeftHand(random: Random, chord: ChordFunction): List<NoteEvent> {
-    val rootMidi = leftHandRootMidi(chord)
-    val fifthMidi = leftHandFifthMidi(chord)
-    val useFifthOnBeatThree = random.nextBoolean()
+    val pattern: List<Pair<Int, Duration>> = when (profile.leftHandStyle) {
+        LeftHandStyle.EASY -> if (random.nextDouble() < 0.65) {
+            listOf(root to Duration.WHOLE)
+        } else {
+            listOf(
+                root to Duration.HALF,
+                (if (random.nextBoolean()) root else fifth) to Duration.HALF
+            )
+        }
+        LeftHandStyle.MEDIUM -> {
+            if (random.nextDouble() < 0.55) {
+                listOf(
+                    root to Duration.HALF,
+                    (if (random.nextBoolean()) fifth else root) to Duration.HALF
+                )
+            } else {
+                listOf(
+                    root to Duration.QUARTER,
+                    fifth to Duration.QUARTER,
+                    third to Duration.QUARTER,
+                    fifth to Duration.QUARTER
+                )
+            }
+        }
+        LeftHandStyle.HARD -> {
+            if (random.nextDouble() < 0.30) {
+                listOf(
+                    root to Duration.HALF,
+                    fifth to Duration.QUARTER,
+                    third to Duration.QUARTER
+                )
+            } else {
+                listOf(
+                    root to Duration.QUARTER,
+                    fifth to Duration.QUARTER,
+                    third to Duration.QUARTER,
+                    (if (random.nextBoolean()) fifth else root) to Duration.QUARTER
+                )
+            }
+        }
+    }
 
-    return listOf(
-        noteFromMidi(rootMidi, Duration.HALF, staff = 2, voice = 2, beatStart = 1),
+    var beatStart = 1
+    return pattern.map { (midi, duration) ->
         noteFromMidi(
-            if (useFifthOnBeatThree) fifthMidi else rootMidi,
-            Duration.HALF,
+            midi = midi,
+            duration = duration,
             staff = 2,
             voice = 2,
-            beatStart = 3
-        )
-    )
+            beatStart = beatStart
+        ).also {
+            beatStart += duration.beats
+        }
+    }
 }
 
 private fun chooseRightHandMidi(
@@ -202,42 +321,42 @@ private fun chooseRightHandMidi(
     chord: ChordFunction,
     previousMidi: Int?,
     mustBeChordTone: Boolean,
-    canUsePerfectFifth: Boolean,
     contourDirection: Int,
     weakBeat: Boolean,
-    recent: List<Int>
+    recent: List<Int>,
+    profile: DifficultyProfile
 ): Int {
-    val candidates = rightHandRange().filter { midi ->
+    val candidates = profile.rightHandRange.filter { midi ->
         isCmajor(midi) && (!mustBeChordTone || isChordTone(midi, chord))
     }
 
     if (previousMidi == null) {
-        val preferred = candidates.filter { it in 64..72 }
-        val pool = if (preferred.isNotEmpty()) preferred else candidates
+        val pool = candidates.filter { it in profile.preferredOpeningRange }.ifEmpty { candidates }
         return pool[random.nextInt(pool.size)]
     }
 
-    val filteredByRepeat = candidates.filterNot { midi ->
-        recent.size == 2 && recent[0] == recent[1] && recent[1] == midi
-    }
-    val repeatAware = if (filteredByRepeat.isNotEmpty()) filteredByRepeat else candidates
+    val repeatAware = candidates.filterNot { midi ->
+        recent.size >= 2 && recent.takeLast(2).all { it == midi }
+    }.ifEmpty { candidates }
 
-    val intervalConstrained = repeatAware.filter { midi ->
-        val diff = abs(midi - previousMidi)
-        diff <= 5 || (diff == 7 && canUsePerfectFifth)
-    }
-    val pool = if (intervalConstrained.isNotEmpty()) intervalConstrained else repeatAware
+    val intervalAware = repeatAware.filter { midi ->
+        abs(midi - previousMidi) <= profile.maxLeap
+    }.ifEmpty { repeatAware }
 
-    val weighted = pool
+    val weighted = intervalAware
         .map { midi ->
             val diff = abs(midi - previousMidi)
             var weight = when {
+                diff == 0 -> 2
                 diff <= 1 -> 7
-                diff <= 2 -> 5
-                diff <= 4 -> 2
-                diff == 5 -> 1
-                diff == 7 -> 1
+                diff <= 2 -> 6
+                diff <= 4 -> 4
+                diff <= 5 -> 2
                 else -> 1
+            }
+
+            if (diff >= 5) {
+                weight = (weight - profile.largeLeapWeightPenalty).coerceAtLeast(1)
             }
 
             if (weakBeat) {
@@ -246,9 +365,11 @@ private fun chooseRightHandMidi(
                     weight += 2
                 }
             }
+
             if (recent.isNotEmpty() && midi == recent.last()) {
-                weight = (weight - 3).coerceAtLeast(1)
+                weight = (weight - profile.repeatPenalty).coerceAtLeast(1)
             }
+
             midi to weight
         }
         .flatMap { (midi, weight) -> List(weight) { midi } }
@@ -256,7 +377,7 @@ private fun chooseRightHandMidi(
     return weighted[random.nextInt(weighted.size)]
 }
 
-private fun rightHandRange(): IntRange = 60..79 // C4..G5
+private fun isAccidentalPitchClass(pitchClass: Int): Boolean = pitchClass in setOf(1, 3, 6, 8, 10)
 
 private fun isCmajor(midi: Int): Boolean = pitchClass(midi) in setOf(0, 2, 4, 5, 7, 9, 11)
 
@@ -273,20 +394,24 @@ private fun isChordTone(midi: Int, chord: ChordFunction): Boolean {
 }
 
 private fun leftHandRootMidi(chord: ChordFunction): Int {
-    // C2..C3 preferred low register
     return when (chord) {
-        ChordFunction.I -> 36   // C2
-        ChordFunction.II -> 38  // D2
-        ChordFunction.III -> 40 // E2
-        ChordFunction.IV -> 41  // F2
-        ChordFunction.V -> 43   // G2
-        ChordFunction.VI -> 45  // A2
+        ChordFunction.I -> 36
+        ChordFunction.II -> 38
+        ChordFunction.III -> 40
+        ChordFunction.IV -> 41
+        ChordFunction.V -> 43
+        ChordFunction.VI -> 45
     }
 }
 
-private fun leftHandFifthMidi(chord: ChordFunction): Int {
-    return leftHandRootMidi(chord) + 7
+private fun leftHandThirdMidi(chord: ChordFunction): Int {
+    return leftHandRootMidi(chord) + when (chord) {
+        ChordFunction.I, ChordFunction.IV, ChordFunction.V -> 4
+        ChordFunction.II, ChordFunction.III, ChordFunction.VI -> 3
+    }
 }
+
+private fun leftHandFifthMidi(chord: ChordFunction): Int = leftHandRootMidi(chord) + 7
 
 private fun noteFromMidi(
     midi: Int,

--- a/core/src/test/kotlin/com/clefrun/core/MusicXmlWriterTest.kt
+++ b/core/src/test/kotlin/com/clefrun/core/MusicXmlWriterTest.kt
@@ -1,0 +1,126 @@
+package com.clefrun.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MusicXmlWriterTest {
+    @Test
+    fun sharpNaturalNaturalInOneMeasureSuppressesRepeatedNatural() {
+        val xml = MusicXmlWriter.write(
+            exerciseWithBars(
+                listOf(
+                    bar(
+                        number = 1,
+                        rightHand = listOf(
+                            note(Step.A, 1, 4, Duration.QUARTER, beatStart = 1, staff = 1),
+                            note(Step.A, 0, 4, Duration.QUARTER, beatStart = 2, staff = 1),
+                            note(Step.A, 0, 4, Duration.HALF, beatStart = 3, staff = 1)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(1, "<accidental>sharp</accidental>".toRegex().findAll(xml).count())
+        assertEquals(1, "<accidental>natural</accidental>".toRegex().findAll(xml).count())
+    }
+
+    @Test
+    fun repeatedSharpInOneMeasureDoesNotRepeatAccidental() {
+        val xml = MusicXmlWriter.write(
+            exerciseWithBars(
+                listOf(
+                    bar(
+                        number = 1,
+                        rightHand = listOf(
+                            note(Step.F, 1, 4, Duration.QUARTER, beatStart = 1, staff = 1),
+                            note(Step.F, 1, 4, Duration.QUARTER, beatStart = 2, staff = 1),
+                            note(Step.F, 1, 4, Duration.HALF, beatStart = 3, staff = 1)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(1, "<accidental>sharp</accidental>".toRegex().findAll(xml).count())
+        assertFalse(xml.contains("<accidental>natural</accidental>"))
+    }
+
+    @Test
+    fun accidentalStateResetsAcrossMeasures() {
+        val xml = MusicXmlWriter.write(
+            exerciseWithBars(
+                listOf(
+                    bar(
+                        number = 1,
+                        rightHand = listOf(
+                            note(Step.F, 1, 4, Duration.WHOLE, beatStart = 1, staff = 1)
+                        )
+                    ),
+                    bar(
+                        number = 2,
+                        rightHand = listOf(
+                            note(Step.F, 1, 4, Duration.WHOLE, beatStart = 1, staff = 1)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(2, "<accidental>sharp</accidental>".toRegex().findAll(xml).count())
+    }
+
+    @Test
+    fun accidentalStateIsIndependentAcrossOctaves() {
+        val xml = MusicXmlWriter.write(
+            exerciseWithBars(
+                listOf(
+                    bar(
+                        number = 1,
+                        rightHand = listOf(
+                            note(Step.A, 1, 4, Duration.QUARTER, beatStart = 1, staff = 1),
+                            note(Step.A, 1, 5, Duration.QUARTER, beatStart = 2, staff = 1),
+                            note(Step.A, 1, 4, Duration.HALF, beatStart = 3, staff = 1)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(2, "<accidental>sharp</accidental>".toRegex().findAll(xml).count())
+    }
+
+    private fun exerciseWithBars(bars: List<Bar>): Exercise {
+        return Exercise(bars = bars)
+    }
+
+    private fun bar(number: Int, rightHand: List<NoteEvent>): Bar {
+        return Bar(
+            number = number,
+            chord = ChordFunction.I,
+            rightHand = rightHand,
+            leftHand = listOf(
+                note(Step.C, 0, 3, Duration.WHOLE, beatStart = 1, staff = 2)
+            )
+        )
+    }
+
+    private fun note(
+        step: Step,
+        alter: Int,
+        octave: Int,
+        duration: Duration,
+        beatStart: Int,
+        staff: Int
+    ): NoteEvent {
+        return NoteEvent(
+            pitch = Pitch(step = step, alter = alter, octave = octave),
+            duration = duration,
+            staff = staff,
+            voice = if (staff == 1) 1 else 2,
+            beatStart = beatStart
+        )
+    }
+}

--- a/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
+++ b/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
@@ -7,19 +7,23 @@ import org.junit.Test
 
 class RuleBasedGeneratorTest {
     @Test
-    fun generatedExerciseHas4Bars() {
-        val exercise = RuleBasedGenerator.generate(seed = 42L)
-        assertEquals(4, exercise.bars.size)
+    fun generatedExerciseHas8BarsForAllDifficulties() {
+        Difficulty.entries.forEach { difficulty ->
+            val exercise = RuleBasedGenerator.generate(seed = 42L, difficulty = difficulty)
+            assertEquals(8, exercise.bars.size)
+        }
     }
 
     @Test
     fun eachBarSumsTo4Beats() {
         val seeds = listOf(1L, 2L, 42L, 100L)
-        seeds.forEach { seed ->
-            val exercise = RuleBasedGenerator.generate(seed)
-            exercise.bars.forEach { bar ->
-                assertEquals(4, bar.rightHand.sumOf { it.duration.beats })
-                assertEquals(4, bar.leftHand.sumOf { it.duration.beats })
+        Difficulty.entries.forEach { difficulty ->
+            seeds.forEach { seed ->
+                val exercise = RuleBasedGenerator.generate(seed = seed, difficulty = difficulty)
+                exercise.bars.forEach { bar ->
+                    assertEquals(4, bar.rightHand.sumOf { it.duration.beats })
+                    assertEquals(4, bar.leftHand.sumOf { it.duration.beats })
+                }
             }
         }
     }
@@ -28,7 +32,7 @@ class RuleBasedGeneratorTest {
     fun accidentalRhNotesResolveBySemitoneIntoChordTone() {
         val seeds = (1L..150L).toList()
         seeds.forEach { seed ->
-            val exercise = RuleBasedGenerator.generate(seed)
+            val exercise = RuleBasedGenerator.generate(seed = seed, difficulty = Difficulty.HARD)
             exercise.bars.forEach { bar ->
                 bar.rightHand.forEachIndexed { index, note ->
                     val pitch = note.pitch ?: return@forEachIndexed
@@ -54,7 +58,7 @@ class RuleBasedGeneratorTest {
     fun leftHandRootDoesNotRepeatExcessivelyAcrossBars() {
         val seeds = (1L..120L).toList()
         seeds.forEach { seed ->
-            val exercise = RuleBasedGenerator.generate(seed)
+            val exercise = RuleBasedGenerator.generate(seed = seed, difficulty = Difficulty.MEDIUM)
             val roots = exercise.bars.map { toMidi(requireNotNull(it.leftHand.first().pitch)) }
             var consecutiveRepeats = 0
             for (i in 1 until roots.size) {
@@ -71,7 +75,7 @@ class RuleBasedGeneratorTest {
     fun rightHandDoesNotContainLongRunsOfSamePitch() {
         val seeds = (1L..120L).toList()
         seeds.forEach { seed ->
-            val exercise = RuleBasedGenerator.generate(seed)
+            val exercise = RuleBasedGenerator.generate(seed = seed, difficulty = Difficulty.MEDIUM)
             val rhMidis = exercise.bars
                 .flatMap { it.rightHand }
                 .map { toMidi(requireNotNull(it.pitch)) }
@@ -91,8 +95,8 @@ class RuleBasedGeneratorTest {
 
     @Test
     fun generatedExerciseStillMeetsDurationAndWriterConstraints() {
-        val exercise = RuleBasedGenerator.generate(seed = 77L)
-        assertEquals(4, exercise.bars.size)
+        val exercise = RuleBasedGenerator.generate(seed = 77L, difficulty = Difficulty.MEDIUM)
+        assertEquals(8, exercise.bars.size)
         exercise.bars.forEach { bar ->
             assertEquals(4, bar.rightHand.sumOf { it.duration.beats })
             assertEquals(4, bar.leftHand.sumOf { it.duration.beats })
@@ -102,7 +106,32 @@ class RuleBasedGeneratorTest {
         assertTrue(xml.startsWith("<?xml"))
         assertTrue(xml.contains("<score-partwise"))
         assertTrue(xml.contains("<part id=\"P1\">"))
-        assertEquals(4, "<measure number=\"".toRegex().findAll(xml).count())
+        assertEquals(8, "<measure number=\"".toRegex().findAll(xml).count())
+    }
+
+    @Test
+    fun harderDifficultiesProduceMoreMotionAndAccidentals() {
+        val seeds = (1L..24L).toList()
+
+        val easyExercises = seeds.map { RuleBasedGenerator.generate(seed = it, difficulty = Difficulty.EASY) }
+        val mediumExercises = seeds.map { RuleBasedGenerator.generate(seed = it, difficulty = Difficulty.MEDIUM) }
+        val hardExercises = seeds.map { RuleBasedGenerator.generate(seed = it, difficulty = Difficulty.HARD) }
+
+        val easyAccidentals = easyExercises.sumOf { countAccidentals(it) }
+        val mediumAccidentals = mediumExercises.sumOf { countAccidentals(it) }
+        val hardAccidentals = hardExercises.sumOf { countAccidentals(it) }
+
+        assertEquals(0, easyAccidentals)
+        assertTrue("Medium should introduce accidentals", mediumAccidentals > easyAccidentals)
+        assertTrue("Hard should introduce at least as many accidentals as medium", hardAccidentals >= mediumAccidentals)
+
+        val easyRhEvents = easyExercises.sumOf { countRightHandEvents(it) }
+        val hardRhEvents = hardExercises.sumOf { countRightHandEvents(it) }
+        assertTrue("Hard should be denser than easy", hardRhEvents > easyRhEvents)
+
+        val easyRange = easyExercises.maxOf { rightHandSpan(it) }
+        val hardRange = hardExercises.maxOf { rightHandSpan(it) }
+        assertTrue("Hard should cover a wider RH span than easy", hardRange > easyRange)
     }
 
     private fun isChordTone(pitch: Pitch, chord: ChordFunction): Boolean {
@@ -121,6 +150,24 @@ class RuleBasedGeneratorTest {
     private fun toMidi(pitch: Pitch): Int {
         val base = (pitch.octave + 1) * 12
         return base + stepToPitchClass(pitch.step) + pitch.alter
+    }
+
+    private fun countAccidentals(exercise: Exercise): Int {
+        return exercise.bars
+            .flatMap { it.rightHand }
+            .count { note -> note.pitch?.alter?.let { it != 0 } == true }
+    }
+
+    private fun countRightHandEvents(exercise: Exercise): Int {
+        return exercise.bars.sumOf { it.rightHand.size }
+    }
+
+    private fun rightHandSpan(exercise: Exercise): Int {
+        val midis = exercise.bars
+            .flatMap { it.rightHand }
+            .map { toMidi(requireNotNull(it.pitch)) }
+        if (midis.isEmpty()) return 0
+        return midis.maxOrNull()!! - midis.minOrNull()!!
     }
 
     private fun stepToPitchClass(step: Step): Int {


### PR DESCRIPTION
## Summary
- wire the selected difficulty into the real generator so New uses the current setting
- add controlled difficulty profiles in :core for range, density, leaps, accidentals, and left-hand activity
- increase the default exercise length from 4 bars to 8 bars while keeping the rendering pipeline unchanged
- keep Tempo visual-only with helper text and add a generic smoke test section to README

## Validation
- ./gradlew assembleDebug --no-daemon
- ./gradlew test --no-daemon