### PR TITLE
feat(scales): add reactive state handling with loading and error UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: tests unit ui build clean install run
+
+tests:
+	./scripts/run-tests.sh
+
+unit:
+	./gradlew test
+
+ui:
+	./gradlew connectedAndroidTest
+
+build:
+	./gradlew build
+
+clean:
+	./gradlew clean
+
+install:
+	./gradlew installDebug
+
+run:
+	./gradlew installDebug
+	adb shell monkey -p com.clefrun.app -c android.intent.category.LAUNCHER 1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.junit.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.core)
-    implementation(libs.kotlinx.collectins.immutable)
+    implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.core)
+    implementation(libs.kotlinx.collectins.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/androidTest/java/com/clefrun/app/feature/scales/ScalesOptionsSheetTest.kt
+++ b/app/src/androidTest/java/com/clefrun/app/feature/scales/ScalesOptionsSheetTest.kt
@@ -1,0 +1,49 @@
+package com.clefrun.app.feature.scales
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.clefrun.core.PracticeMode
+import com.clefrun.core.PracticeTonic
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Rule
+import org.junit.Test
+
+class ScalesOptionsSheetTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun selecting_tonic_updates_selected_chip() {
+        composeRule.setContent {
+            var selected by remember { mutableStateOf(PracticeTonic.F) }
+
+            ScalesOptionsSheet(
+                selectedMode = PracticeMode.MAJOR,
+                selectedTonic = selected,
+                supportedModes = persistentSetOf(PracticeMode.MAJOR),
+                supportedTonics = persistentSetOf(
+                    PracticeTonic.F,
+                    PracticeTonic.C
+                ),
+                onModeSelected = {},
+                onTonicSelected = { selected = it },
+            )
+        }
+
+        composeRule
+            .onNodeWithTag("tonic-chip-C")
+            .performClick()
+
+        composeRule
+            .onNodeWithTag("tonic-chip-C")
+            .assertIsSelected()
+    }
+
+}

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScaleSelection.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScaleSelection.kt
@@ -1,0 +1,9 @@
+package com.clefrun.app.feature.scales
+
+import com.clefrun.core.PracticeMode
+import com.clefrun.core.PracticeTonic
+
+data class ScaleSelection(
+    val mode: PracticeMode,
+    val tonic: PracticeTonic
+)

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
@@ -71,10 +71,12 @@ internal fun ScalesScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val onErrorDismissed = viewModel::onErrorDismissed
 
     if (isLandscape) {
         LandscapeScalesContent(
-            musicXml = uiState.currentMusicXml,
+            uiState = uiState,
+            onErrorDismissed = onErrorDismissed,
             modifier = modifier
         )
     } else {
@@ -82,9 +84,16 @@ internal fun ScalesScreen(
             uiState = uiState,
             onModeSelected = viewModel::onModeSelected,
             onTonicSelected = viewModel::onTonicSelected,
-            onErrorDismissed = viewModel::onErrorDismissed,
+            onErrorDismissed = onErrorDismissed,
             modifier = modifier
         )
+    }
+
+    uiState.error?.let { error ->
+        LaunchedEffect(error) {
+            delay(3000)
+            onErrorDismissed()
+        }
     }
 }
 
@@ -105,13 +114,6 @@ private fun PortraitScalesContent(
         )
     )
     val scope = rememberCoroutineScope()
-
-    uiState.error?.let {
-        LaunchedEffect(it) {
-            delay(3000)
-            onErrorDismissed()
-        }
-    }
 
     BottomSheetScaffold(
         modifier = modifier.fillMaxSize(),
@@ -200,7 +202,8 @@ private fun PortraitScalesContent(
 
 @Composable
 private fun LandscapeScalesContent(
-    musicXml: String,
+    uiState: ScalesUiState,
+    onErrorDismissed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -212,10 +215,19 @@ private fun LandscapeScalesContent(
             .padding(horizontal = 6.dp, vertical = 6.dp)
     ) {
         ScoreSurface(
-            musicXml = musicXml,
+            musicXml = uiState.currentMusicXml,
             showMeasureNumbers = false,
             modifier = Modifier.fillMaxSize()
         )
+
+        ScalesErrorBanner(
+            error = uiState.error,
+            onDismissed = onErrorDismissed,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .zIndex(1f)
+        )
+
     }
 }
 

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
@@ -1,6 +1,11 @@
 package com.clefrun.app.feature.scales
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -29,6 +35,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +44,8 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clefrun.app.feature.sightreading.ScoreSurface
 import com.clefrun.app.ui.components.ClefRunLogo
 import com.clefrun.app.ui.theme.AppBackground
@@ -48,6 +58,8 @@ import com.clefrun.app.ui.theme.TextPrimary
 import com.clefrun.app.ui.theme.TextSecondary
 import com.clefrun.core.PracticeMode
 import com.clefrun.core.PracticeTonic
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -56,17 +68,21 @@ internal fun ScalesScreen(
     viewModel: ScalesViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
     if (isLandscape) {
-        LandscapeScalesScreen(
-            musicXml = viewModel.currentMusicXml,
+        LandscapeScalesContent(
+            musicXml = uiState.currentMusicXml,
             modifier = modifier
         )
     } else {
-        PortraitScalesScreen(
-            viewModel = viewModel,
+        PortraitScalesContent(
+            uiState = uiState,
+            onModeSelected = viewModel::onModeSelected,
+            onTonicSelected = viewModel::onTonicSelected,
+            onErrorDismissed = viewModel::onErrorDismissed,
             modifier = modifier
         )
     }
@@ -74,10 +90,14 @@ internal fun ScalesScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-private fun PortraitScalesScreen(
-    viewModel: ScalesViewModel,
+private fun PortraitScalesContent(
+    uiState: ScalesUiState,
+    onModeSelected: (PracticeMode) -> Unit,
+    onTonicSelected: (PracticeTonic) -> Unit,
+    onErrorDismissed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
     val scaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberStandardBottomSheetState(
             initialValue = SheetValue.PartiallyExpanded,
@@ -85,6 +105,13 @@ private fun PortraitScalesScreen(
         )
     )
     val scope = rememberCoroutineScope()
+
+    uiState.error?.let {
+        LaunchedEffect(it) {
+            delay(3000)
+            onErrorDismissed()
+        }
+    }
 
     BottomSheetScaffold(
         modifier = modifier.fillMaxSize(),
@@ -104,12 +131,12 @@ private fun PortraitScalesScreen(
         },
         sheetContent = {
             ScalesOptionsSheet(
-                selectedMode = viewModel.selectedMode,
-                selectedTonic = viewModel.selectedTonic,
-                onModeSelected = viewModel::onModeSelected,
-                onTonicSelected = viewModel::onTonicSelected,
-                isModeSupported = viewModel::isModeSupported,
-                isTonicSupported = viewModel::isTonicSupported,
+                selectedMode = uiState.selectedMode,
+                selectedTonic = uiState.selectedTonic,
+                onModeSelected = onModeSelected,
+                onTonicSelected = onTonicSelected,
+                supportedModes = uiState.supportedModes,
+                supportedTonics = uiState.supportedTonics,
                 modifier = Modifier
                     .fillMaxWidth()
                     .navigationBarsPadding()
@@ -137,21 +164,42 @@ private fun PortraitScalesScreen(
                 }
             )
 
-            ScoreSurface(
-                musicXml = viewModel.currentMusicXml,
-                showMeasureNumbers = false,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
                     .padding(horizontal = 12.dp)
-                    .padding(bottom = 28.dp)
-            )
+                    .padding(bottom = 28.dp),
+            ) {
+
+                ScoreSurface(
+                    musicXml = uiState.currentMusicXml,
+                    showMeasureNumbers = false,
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                ScalesErrorBanner(
+                    error = uiState.error,
+                    onDismissed = onErrorDismissed,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .zIndex(1f)
+                )
+
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .zIndex(1f)
+                    )
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun LandscapeScalesScreen(
+private fun LandscapeScalesContent(
     musicXml: String,
     modifier: Modifier = Modifier,
 ) {
@@ -213,8 +261,8 @@ private fun ScalesOptionsSheet(
     selectedTonic: PracticeTonic,
     onModeSelected: (PracticeMode) -> Unit,
     onTonicSelected: (PracticeTonic) -> Unit,
-    isModeSupported: (PracticeMode) -> Boolean,
-    isTonicSupported: (PracticeTonic) -> Boolean,
+    supportedModes: ImmutableSet<PracticeMode>,
+    supportedTonics: ImmutableSet<PracticeTonic>,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -235,7 +283,7 @@ private fun ScalesOptionsSheet(
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             PracticeMode.entries.forEach { mode ->
-                val enabled = isModeSupported(mode)
+                val enabled = mode in supportedModes
                 FilterChip(
                     selected = mode == selectedMode,
                     onClick = { onModeSelected(mode) },
@@ -279,7 +327,7 @@ private fun ScalesOptionsSheet(
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             PracticeTonic.entries.forEach { tonic ->
-                val enabled = isTonicSupported(tonic)
+                val enabled = tonic in supportedTonics
                 FilterChip(
                     selected = tonic == selectedTonic,
                     onClick = { onTonicSelected(tonic) },
@@ -312,6 +360,38 @@ private fun ScalesOptionsSheet(
     }
 }
 
+@Composable
+private fun ScalesErrorBanner(
+    error: ScalesError?,
+    onDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = error != null,
+        enter = slideInVertically { -it } + fadeIn(),
+        exit = slideOutVertically { -it } + fadeOut(),
+        modifier = modifier
+    ) {
+        error?.let {
+            Surface(
+                onClick = onDismissed,
+                color = Paper,
+                contentColor = Charcoal,
+                shape = RoundedCornerShape(12.dp),
+                shadowElevation = 6.dp,
+                tonalElevation = 2.dp,
+                modifier = Modifier.padding(top = 12.dp, start = 24.dp, end = 24.dp)
+            ) {
+                Text(
+                    text = it.message(),
+                    modifier = Modifier.padding(12.dp),
+                    fontSize = 14.sp
+                )
+            }
+        }
+    }
+}
+
 private val PracticeMode.label: String
     get() = when (this) {
         PracticeMode.MAJOR -> "Major"
@@ -319,3 +399,7 @@ private val PracticeMode.label: String
         PracticeMode.HARMONIC_MINOR -> "Harmonic minor"
         PracticeMode.MELODIC_MINOR -> "Melodic minor"
     }
+
+private fun ScalesError.message(): String = when (this) {
+    ScalesError.GenerationFailed -> "Couldn’t generate the scale. Please try again."
+}

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesScreen.kt
@@ -1,6 +1,7 @@
 package com.clefrun.app.feature.scales
 
 import android.content.res.Configuration
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -41,6 +42,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -267,8 +269,9 @@ private fun ScalesTopOverlayBar(
     }
 }
 
+@VisibleForTesting
 @Composable
-private fun ScalesOptionsSheet(
+fun ScalesOptionsSheet(
     selectedMode: PracticeMode,
     selectedTonic: PracticeTonic,
     onModeSelected: (PracticeMode) -> Unit,
@@ -358,7 +361,8 @@ private fun ScalesOptionsSheet(
                         selected = tonic == selectedTonic,
                         borderColor = Stroke,
                         selectedBorderColor = Stroke
-                    )
+                    ),
+                    modifier = Modifier.testTag("tonic-chip-${tonic.name}")
                 )
             }
         }

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
@@ -1,67 +1,149 @@
 package com.clefrun.app.feature.scales
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import android.util.Log
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clefrun.core.PracticeMode
 import com.clefrun.core.PracticeTonic
-import com.clefrun.core.isTechnicalPracticeSupported
 import com.clefrun.core.supportedTechnicalPracticeModes
 import com.clefrun.core.supportedTechnicalPracticeTonics
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.toImmutableSet
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
+@Immutable
+data class ScalesUiState(
+    val selectedMode: PracticeMode = PracticeMode.MAJOR,
+    val selectedTonic: PracticeTonic = PracticeTonic.F,
+    val supportedModes: ImmutableSet<PracticeMode> = supportedTechnicalPracticeModes().toImmutableSet(),
+    val supportedTonics: ImmutableSet<PracticeTonic> = supportedTechnicalPracticeTonics(PracticeMode.MAJOR).toImmutableSet(),
+    val currentMusicXml: String = "",
+    val isLoading: Boolean = false,
+    val error: ScalesError? = null,
+)
+
+sealed interface ScalesError {
+    data object GenerationFailed : ScalesError
+}
+
 class ScalesViewModel : ViewModel() {
-    private var generationJob: Job? = null
 
-    var selectedMode by mutableStateOf(PracticeMode.MAJOR)
-        private set
+    private val selection = MutableStateFlow(
+        ScaleSelection(
+            mode = PracticeMode.MAJOR,
+            tonic = PracticeTonic.F
+        )
+    )
 
-    var selectedTonic by mutableStateOf(PracticeTonic.F)
-        private set
-
-    var currentMusicXml by mutableStateOf("")
-        private set
+    private val _uiState = MutableStateFlow(ScalesUiState())
+    val uiState: StateFlow<ScalesUiState> = _uiState.asStateFlow()
 
     init {
-        regenerate()
+        observeSelection()
     }
 
     fun onModeSelected(mode: PracticeMode) {
-        if (selectedMode == mode || !isModeSupported(mode)) return
-        selectedMode = mode
-        if (!isTonicSupported(selectedTonic)) {
-            selectedTonic = supportedTechnicalPracticeTonics(mode).first()
+        val state = uiState.value
+        if (state.selectedMode == mode || mode !in state.supportedModes) return
+
+        val supportedTonics = supportedTechnicalPracticeTonics(mode).toImmutableSet()
+        val tonic = if (state.selectedTonic in supportedTonics) {
+            state.selectedTonic
+        } else {
+            supportedTonics.first()
         }
-        regenerate()
+
+        selection.value = ScaleSelection(mode, tonic)
     }
 
     fun onTonicSelected(tonic: PracticeTonic) {
-        if (selectedTonic == tonic || !isTonicSupported(tonic)) return
-        selectedTonic = tonic
-        regenerate()
+        val state = uiState.value
+        if (state.selectedTonic == tonic) return
+        if (tonic !in state.supportedTonics) return
+
+        selection.value = ScaleSelection(state.selectedMode, tonic)
     }
 
-    fun isModeSupported(mode: PracticeMode): Boolean {
-        return supportedTechnicalPracticeModes().contains(mode)
+    fun onErrorDismissed() {
+        clearError()
     }
 
-    fun isTonicSupported(tonic: PracticeTonic): Boolean {
-        return isTechnicalPracticeSupported(selectedMode, tonic)
-    }
-
-    private fun regenerate() {
-        if (!isTechnicalPracticeSupported(selectedMode, selectedTonic)) return
-        generationJob?.cancel()
-        generationJob = viewModelScope.launch {
-            val xml = withContext(Dispatchers.Default) {
-                generateTechnicalPracticeXml(selectedMode, selectedTonic)
-            }
-            currentMusicXml = xml
+    private fun clearError() {
+        _uiState.update {
+            it.copy(error = null)
         }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeSelection() {
+        selection
+            .onEach { selected ->
+                val supportedTonics =
+                    supportedTechnicalPracticeTonics(selected.mode).toImmutableSet()
+
+                _uiState.update {
+                    it.copy(
+                        selectedMode = selected.mode,
+                        selectedTonic = selected.tonic,
+                        supportedTonics = supportedTonics,
+                        isLoading = true,
+                        error = null
+                    )
+                }
+            }
+            .flatMapLatest { selected ->
+                flow {
+                    val xml = withContext(Dispatchers.Default) {
+                        generateTechnicalPracticeXml(selected.mode, selected.tonic)
+                    }
+                    emit(xml)
+                }
+                    .map { Result.success(it) }
+                    .catch { throwable ->
+                        if (throwable is CancellationException) throw throwable
+                        Log.e(TAG, "Failed to generate music XML", throwable)
+                        emit(Result.failure(throwable))
+                    }
+            }
+            .onEach { result ->
+                result.fold(
+                    onSuccess = { xml ->
+                        _uiState.update {
+                            it.copy(
+                                currentMusicXml = xml,
+                                isLoading = false,
+                                error = null,
+                            )
+                        }
+                    },
+                    onFailure = {
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = ScalesError.GenerationFailed
+                            )
+                        }
+                    }
+                )
+            }
+            .launchIn(viewModelScope)
+    }
+
+    companion object {
+        private const val TAG = "ScalesViewModel"
     }
 }

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
@@ -12,6 +12,7 @@ import com.clefrun.core.supportedTechnicalPracticeTonics
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +44,11 @@ sealed interface ScalesError {
     data object GenerationFailed : ScalesError
 }
 
-class ScalesViewModel : ViewModel() {
+class ScalesViewModel(
+    private val generateXml: suspend (mode: PracticeMode, tonic: PracticeTonic) -> String = ::generateTechnicalPracticeXml,
+    private val generationDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val logger: (String, Throwable?) -> Unit = { msg, t -> Log.e(TAG, msg, t) }
+) : ViewModel() {
 
     private val selection = MutableStateFlow(
         ScaleSelection(
@@ -60,12 +65,14 @@ class ScalesViewModel : ViewModel() {
     }
 
     fun onModeSelected(mode: PracticeMode) {
+        val currentSelection = selection.value
         val state = uiState.value
-        if (state.selectedMode == mode || mode !in state.supportedModes) return
+
+        if (currentSelection.mode == mode || mode !in state.supportedModes) return
 
         val supportedTonics = supportedTechnicalPracticeTonics(mode).toImmutableSet()
-        val tonic = if (state.selectedTonic in supportedTonics) {
-            state.selectedTonic
+        val tonic = if (currentSelection.tonic in supportedTonics) {
+            currentSelection.tonic
         } else {
             TechnicalPracticeDefaults.tonic
         }
@@ -74,11 +81,13 @@ class ScalesViewModel : ViewModel() {
     }
 
     fun onTonicSelected(tonic: PracticeTonic) {
+        val currentSelection = selection.value
         val state = uiState.value
-        if (state.selectedTonic == tonic) return
+
+        if (currentSelection.tonic == tonic) return
         if (tonic !in state.supportedTonics) return
 
-        selection.value = ScaleSelection(state.selectedMode, tonic)
+        selection.value = currentSelection.copy(tonic = tonic)
     }
 
     fun onErrorDismissed() {
@@ -110,15 +119,15 @@ class ScalesViewModel : ViewModel() {
             }
             .flatMapLatest { selected ->
                 flow {
-                    val xml = withContext(Dispatchers.Default) {
-                        generateTechnicalPracticeXml(selected.mode, selected.tonic)
+                    val xml = withContext(generationDispatcher) {
+                        generateXml(selected.mode, selected.tonic)
                     }
                     emit(xml)
                 }
                     .map { Result.success(it) }
                     .catch { throwable ->
                         if (throwable is CancellationException) throw throwable
-                        Log.e(TAG, "Failed to generate music XML", throwable)
+                        logger("Failed to generate music XML", throwable)
                         emit(Result.failure(throwable))
                     }
             }

--- a/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
+++ b/app/src/main/java/com/clefrun/app/feature/scales/ScalesViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clefrun.core.PracticeMode
 import com.clefrun.core.PracticeTonic
+import com.clefrun.core.TechnicalPracticeDefaults
 import com.clefrun.core.supportedTechnicalPracticeModes
 import com.clefrun.core.supportedTechnicalPracticeTonics
 import kotlinx.collections.immutable.ImmutableSet
@@ -27,10 +28,12 @@ import kotlinx.coroutines.withContext
 
 @Immutable
 data class ScalesUiState(
-    val selectedMode: PracticeMode = PracticeMode.MAJOR,
-    val selectedTonic: PracticeTonic = PracticeTonic.F,
+    val selectedMode: PracticeMode = TechnicalPracticeDefaults.mode,
+    val selectedTonic: PracticeTonic = TechnicalPracticeDefaults.tonic,
     val supportedModes: ImmutableSet<PracticeMode> = supportedTechnicalPracticeModes().toImmutableSet(),
-    val supportedTonics: ImmutableSet<PracticeTonic> = supportedTechnicalPracticeTonics(PracticeMode.MAJOR).toImmutableSet(),
+    val supportedTonics: ImmutableSet<PracticeTonic> = supportedTechnicalPracticeTonics(
+        TechnicalPracticeDefaults.mode
+    ).toImmutableSet(),
     val currentMusicXml: String = "",
     val isLoading: Boolean = false,
     val error: ScalesError? = null,
@@ -44,8 +47,8 @@ class ScalesViewModel : ViewModel() {
 
     private val selection = MutableStateFlow(
         ScaleSelection(
-            mode = PracticeMode.MAJOR,
-            tonic = PracticeTonic.F
+            mode = TechnicalPracticeDefaults.mode,
+            tonic = TechnicalPracticeDefaults.tonic
         )
     )
 
@@ -64,7 +67,7 @@ class ScalesViewModel : ViewModel() {
         val tonic = if (state.selectedTonic in supportedTonics) {
             state.selectedTonic
         } else {
-            supportedTonics.first()
+            TechnicalPracticeDefaults.tonic
         }
 
         selection.value = ScaleSelection(mode, tonic)

--- a/app/src/test/java/com/clefrun/app/MainDispatcherRule.kt
+++ b/app/src/test/java/com/clefrun/app/MainDispatcherRule.kt
@@ -1,0 +1,24 @@
+package com.clefrun.app
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/clefrun/app/feature/scales/ScalesViewModelTest.kt
+++ b/app/src/test/java/com/clefrun/app/feature/scales/ScalesViewModelTest.kt
@@ -1,0 +1,152 @@
+package com.clefrun.app.feature.scales
+
+import com.clefrun.app.MainDispatcherRule
+import com.clefrun.core.PracticeMode
+import com.clefrun.core.PracticeTonic
+import com.clefrun.core.TechnicalPracticeDefaults
+import com.clefrun.core.supportedTechnicalPracticeTonics
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScalesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `initial state generates default scale`() = runTest(mainDispatcherRule.dispatcher) {
+        val viewModel = createViewModel()
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+
+        assertEquals(TechnicalPracticeDefaults.mode, state.selectedMode)
+        assertEquals(TechnicalPracticeDefaults.tonic, state.selectedTonic)
+        assertEquals(
+            "xml-${TechnicalPracticeDefaults.mode}-${TechnicalPracticeDefaults.tonic}",
+            state.currentMusicXml
+        )
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `selecting tonic updates state and generates new xml`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val newTonic = supportedTechnicalPracticeTonics(TechnicalPracticeDefaults.mode)
+                .first { it != TechnicalPracticeDefaults.tonic }
+            viewModel.onTonicSelected(newTonic)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+
+            assertEquals(newTonic, state.selectedTonic)
+            assertEquals(
+                "xml-${state.selectedMode}-${newTonic}",
+                state.currentMusicXml
+            )
+            assertFalse(state.isLoading)
+            assertNull(state.error)
+        }
+
+    @Test
+    fun `generation failure updates error state`() = runTest(mainDispatcherRule.dispatcher) {
+        val viewModel = createViewModel(
+            generateXml = { _, _ -> throw RuntimeException("Generation failed") }
+        )
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+
+        assertEquals(ScalesError.GenerationFailed, state.error)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `generation backpressure cancels stale selection and uses latest selection`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            val defaultTonic = TechnicalPracticeDefaults.tonic
+            val intermediateTonic = supportedTechnicalPracticeTonics(TechnicalPracticeDefaults.mode)
+                .first { it != defaultTonic }
+
+            val intermediateStarted = CompletableDeferred<Unit>()
+            val allowIntermediateToFinish = CompletableDeferred<Unit>()
+
+            val viewModel = createViewModel(
+                generateXml = { mode, tonic ->
+                    if (tonic == intermediateTonic) {
+                        intermediateStarted.complete(Unit)
+                        allowIntermediateToFinish.await()
+                    }
+
+                    "xml-$mode-$tonic"
+                }
+            )
+
+            advanceUntilIdle()
+
+            viewModel.onTonicSelected(intermediateTonic)
+
+            intermediateStarted.await()
+
+            viewModel.onTonicSelected(defaultTonic)
+
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+
+            assertEquals(defaultTonic, state.selectedTonic)
+            assertEquals(
+                "xml-${TechnicalPracticeDefaults.mode}-$defaultTonic",
+                state.currentMusicXml
+            )
+        }
+
+    @Test
+    fun `loading is cleared after successful generation`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            val started = CompletableDeferred<Unit>()
+            val finish = CompletableDeferred<Unit>()
+
+            val viewModel = createViewModel(
+                generateXml = { mode, tonic ->
+                    // Simulate a long-running generation
+                    started.complete(Unit)
+                    finish.await()
+                    "xml-$mode-$tonic"
+                }
+            )
+            started.await()
+            assertTrue(viewModel.uiState.value.isLoading)
+
+            finish.complete(Unit)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    private fun createViewModel(
+        generateXml: suspend (PracticeMode, PracticeTonic) -> String =
+            { mode, tonic -> "xml-$mode-$tonic" },
+    ): ScalesViewModel {
+        return ScalesViewModel(
+            generateXml = generateXml,
+            generationDispatcher = mainDispatcherRule.dispatcher,
+            logger = { _, _ -> }
+        )
+    }
+}

--- a/core/src/main/kotlin/com/clefrun/core/Domain.kt
+++ b/core/src/main/kotlin/com/clefrun/core/Domain.kt
@@ -115,3 +115,8 @@ enum class PracticeTonic {
     A,
     B
 }
+
+object TechnicalPracticeDefaults {
+    val mode: PracticeMode = PracticeMode.MAJOR
+    val tonic: PracticeTonic = PracticeTonic.F
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "nav3Core" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
-kotlinx-collectins-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ jetbrainsKotlinJvm = "2.3.10"
 nav3Core = "1.0.1"
 kotlinxSerializationCore = "1.9.0"
 kotlinxCollectionsImmutable = "0.4.0"
+kotlinxCoroutines = "1.10.2"
+junitJunit = "4.12"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,6 +35,8 @@ androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigat
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "nav3Core" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+junit-junit = { group = "junit", name = "junit", version.ref = "junitJunit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2026.02.01"
 jetbrainsKotlinJvm = "2.3.10"
 nav3Core = "1.0.1"
 kotlinxSerializationCore = "1.9.0"
+kotlinxCollectionsImmutable = "0.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "nav3Core" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
+kotlinx-collectins-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Running unit tests..."
+./gradlew test
+
+echo "Running instrumented tests..."
+./gradlew connectedAndroidTest
+
+echo "All tests finished!"


### PR DESCRIPTION
## Summary
Refactors the Scales screen to use StateFlow-based UDF and adds loading/error UI states.

The Scales feature started as a PoC to validate MusicXML generation and rendering. This PR evolves the implementation toward a more maintainable structure by introducing UDF-style state management, lifecycle-aware state collection, and basic UI feedback (loading/error).

The goal is to preserve iteration speed while gradually applying production-ready patterns as the feature matures.

## Scope and trade-offs

The feature is intentionally not over-engineered at this stage. The current focus is on improving the exercise generator to produce musically meaningful and ergonomically playable patterns.

Additional architectural layers (e.g. DI, further separation) can be introduced once the domain logic stabilizes.

## Changes
- Introduced `ScalesUiState`
- Migrated state handling to `StateFlow`
- Implemented latest-wins generation using `flatMapLatest`
- Added loading indicator
- Added animated error banner
- Added ViewModel unit tests
- Added basic Compose UI test