### PR TITLE
Milestone 12: Targeted practice input

### DIFF
--- a/app/src/main/java/com/clefrun/app/coach/ExercisePlan.kt
+++ b/app/src/main/java/com/clefrun/app/coach/ExercisePlan.kt
@@ -1,12 +1,21 @@
 package com.clefrun.app.coach
 
 import com.clefrun.core.Difficulty
+import com.clefrun.core.ExerciseFocus
+
+data class ExercisePlanRequest(
+    val seed: Long,
+    val difficulty: Difficulty,
+    val targetedPracticeText: String? = null,
+)
 
 data class ExercisePlan(
     val id: String,
+    val seed: Long,
     val source: ExercisePlanSource,
     val mode: ExercisePlanMode,
     val difficulty: Difficulty,
+    val generatorFocus: ExerciseFocus,
     val focus: String,
     val constraints: List<String> = emptyList(),
     val coach: CoachContent,

--- a/app/src/main/java/com/clefrun/app/coach/ExercisePlanProvider.kt
+++ b/app/src/main/java/com/clefrun/app/coach/ExercisePlanProvider.kt
@@ -1,47 +1,69 @@
 package com.clefrun.app.coach
 
-import com.clefrun.core.Difficulty
+import com.clefrun.core.ExerciseFocus
 
 fun interface ExercisePlanProvider {
-    fun nextSightReadingPlan(
-        seed: Long,
-        difficulty: Difficulty,
-    ): ExercisePlan
+    fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan
 }
 
 class LocalExercisePlanProvider : ExercisePlanProvider {
-    override fun nextSightReadingPlan(
-        seed: Long,
-        difficulty: Difficulty,
-    ): ExercisePlan {
-        val index = (((seed - 1L) % tips.size) + tips.size) % tips.size
-        val tip = tips[index.toInt()]
+    override fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan {
+        val focus = focusFor(request.targetedPracticeText)
+        val tip = tipFor(focus)
         return ExercisePlan(
-            id = "local-sight-reading-$seed",
+            id = "local-sight-reading-${request.seed}",
+            seed = request.seed,
             source = ExercisePlanSource.LOCAL,
             mode = ExercisePlanMode.SIGHT_READING,
-            difficulty = difficulty,
+            difficulty = request.difficulty,
+            generatorFocus = focus,
             focus = tip.focusLabel,
             coach = tip,
         )
     }
 }
 
-private val tips = listOf(
-    CoachContent(
-        title = "Coach tip",
-        focusLabel = "Read ahead",
-        body = "Look one beat ahead and keep the left hand light while the right hand moves.",
-    ),
-    CoachContent(
-        title = "Coach tip",
-        focusLabel = "Block chords together",
-        body = "When you see a chord, press all notes at the same time.",
-        watchOut = "Avoid rolling them like an arpeggio.",
-    ),
-    CoachContent(
-        title = "Coach tip",
-        focusLabel = "Steady rhythm",
-        body = "Keep counting through the bar and avoid stopping when the hands move separately.",
-    ),
-)
+private fun focusFor(targetedPracticeText: String?): ExerciseFocus {
+    val text = targetedPracticeText?.lowercase().orEmpty()
+    if (text.isBlank()) return ExerciseFocus.READ_AHEAD
+
+    return when {
+        text.contains("left") || text.contains("bass") -> ExerciseFocus.LEFT_HAND_STABILITY
+        text.contains("accidental") ||
+            text.contains("sharp") ||
+            text.contains("flat") ||
+            text.contains("sharps") ||
+            text.contains("flats") -> ExerciseFocus.ACCIDENTALS
+        text.contains("leap") ||
+            text.contains("leaps") ||
+            text.contains("jump") ||
+            text.contains("jumps") -> ExerciseFocus.SMALL_LEAPS
+        text.contains("chord") || text.contains("chords") -> ExerciseFocus.READ_AHEAD
+        else -> ExerciseFocus.READ_AHEAD
+    }
+}
+
+private fun tipFor(focus: ExerciseFocus): CoachContent {
+    return when (focus) {
+        ExerciseFocus.READ_AHEAD -> CoachContent(
+            title = "Coach tip",
+            focusLabel = "Read ahead",
+            body = "Look one beat ahead and keep the pulse steady through the full phrase.",
+        )
+        ExerciseFocus.LEFT_HAND_STABILITY -> CoachContent(
+            title = "Coach tip",
+            focusLabel = "Left hand stability",
+            body = "Keep the left hand steady and light while reading the right hand one beat ahead.",
+        )
+        ExerciseFocus.ACCIDENTALS -> CoachContent(
+            title = "Coach tip",
+            focusLabel = "Accidentals",
+            body = "Scan for altered notes before you start, then keep the pulse steady when they appear.",
+        )
+        ExerciseFocus.SMALL_LEAPS -> CoachContent(
+            title = "Coach tip",
+            focusLabel = "Small leaps",
+            body = "Read the interval shape before moving, and prepare the next hand position early.",
+        )
+    }
+}

--- a/app/src/main/java/com/clefrun/app/coach/ExercisePlanProvider.kt
+++ b/app/src/main/java/com/clefrun/app/coach/ExercisePlanProvider.kt
@@ -1,6 +1,7 @@
 package com.clefrun.app.coach
 
 import com.clefrun.core.ExerciseFocus
+import java.util.Locale
 
 fun interface ExercisePlanProvider {
     fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan
@@ -24,24 +25,28 @@ class LocalExercisePlanProvider : ExercisePlanProvider {
 }
 
 private fun focusFor(targetedPracticeText: String?): ExerciseFocus {
-    val text = targetedPracticeText?.lowercase().orEmpty()
-    if (text.isBlank()) return ExerciseFocus.READ_AHEAD
+    val tokens = targetedPracticeText
+        ?.lowercase(Locale.ROOT)
+        ?.split(NonLetterRegex)
+        ?.filter { it.isNotBlank() }
+        ?.toSet()
+        .orEmpty()
+    if (tokens.isEmpty()) return ExerciseFocus.READ_AHEAD
 
     return when {
-        text.contains("left") || text.contains("bass") -> ExerciseFocus.LEFT_HAND_STABILITY
-        text.contains("accidental") ||
-            text.contains("sharp") ||
-            text.contains("flat") ||
-            text.contains("sharps") ||
-            text.contains("flats") -> ExerciseFocus.ACCIDENTALS
-        text.contains("leap") ||
-            text.contains("leaps") ||
-            text.contains("jump") ||
-            text.contains("jumps") -> ExerciseFocus.SMALL_LEAPS
-        text.contains("chord") || text.contains("chords") -> ExerciseFocus.READ_AHEAD
+        tokens.any { it in leftHandTokens } -> ExerciseFocus.LEFT_HAND_STABILITY
+        tokens.any { it in accidentalTokens } -> ExerciseFocus.ACCIDENTALS
+        tokens.any { it in smallLeapTokens } -> ExerciseFocus.SMALL_LEAPS
+        tokens.any { it in chordTokens } -> ExerciseFocus.READ_AHEAD
         else -> ExerciseFocus.READ_AHEAD
     }
 }
+
+private val NonLetterRegex = Regex("[^\\p{L}]+")
+private val leftHandTokens = setOf("left", "bass")
+private val accidentalTokens = setOf("accidental", "accidentals", "sharp", "sharps", "flat", "flats")
+private val smallLeapTokens = setOf("leap", "leaps", "jump", "jumps")
+private val chordTokens = setOf("chord", "chords")
 
 private fun tipFor(focus: ExerciseFocus): CoachContent {
     return when (focus) {

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/ExerciseXmlFactory.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/ExerciseXmlFactory.kt
@@ -1,10 +1,14 @@
 package com.clefrun.app.feature.sightreading
 
-import com.clefrun.core.Difficulty
+import com.clefrun.app.coach.ExercisePlan
 import com.clefrun.core.MusicXmlWriter
 import com.clefrun.core.RuleBasedGenerator
 
-internal fun generateExerciseXml(seed: Long, difficulty: Difficulty): String {
-    val exercise = RuleBasedGenerator.generate(seed, difficulty)
+internal fun generateExerciseXml(exercisePlan: ExercisePlan): String {
+    val exercise = RuleBasedGenerator.generate(
+        seed = exercisePlan.seed,
+        difficulty = exercisePlan.difficulty,
+        focus = exercisePlan.generatorFocus
+    )
     return MusicXmlWriter.write(exercise)
 }

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/OptionsSheetContent.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/OptionsSheetContent.kt
@@ -22,8 +22,11 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.text.font.FontWeight
@@ -40,7 +43,6 @@ import com.clefrun.app.ui.theme.TextSecondary
 import com.clefrun.app.ui.theme.WarmAccent
 import com.clefrun.core.Difficulty
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun OptionsSheetContent(
@@ -55,7 +57,15 @@ internal fun OptionsSheetContent(
 ) {
     val scrollState = rememberScrollState()
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
-    val scope = rememberCoroutineScope()
+    var isTargetedPracticeFocused by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isTargetedPracticeFocused) {
+        if (isTargetedPracticeFocused) {
+            onTargetedPracticeFocused()
+            delay(TargetedPracticeBringIntoViewDelayMillis)
+            bringIntoViewRequester.bringIntoView()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -105,13 +115,7 @@ internal fun OptionsSheetContent(
                         .padding(top = 10.dp)
                         .bringIntoViewRequester(bringIntoViewRequester)
                         .onFocusEvent { focusState ->
-                            if (focusState.isFocused) {
-                                scope.launch {
-                                    onTargetedPracticeFocused()
-                                    delay(TargetedPracticeBringIntoViewDelayMillis)
-                                    bringIntoViewRequester.bringIntoView()
-                                }
-                            }
+                            isTargetedPracticeFocused = focusState.isFocused
                         },
                     label = { Text("Targeted practice") },
                     placeholder = { Text("e.g. left hand, accidentals, small jumps") },

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/OptionsSheetContent.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/OptionsSheetContent.kt
@@ -5,9 +5,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -16,7 +22,10 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -30,17 +39,28 @@ import com.clefrun.app.ui.theme.TextPrimary
 import com.clefrun.app.ui.theme.TextSecondary
 import com.clefrun.app.ui.theme.WarmAccent
 import com.clefrun.core.Difficulty
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun OptionsSheetContent(
     selectedDifficulty: Difficulty,
     onDifficultySelected: (Difficulty) -> Unit,
+    targetedPracticeText: String,
+    onTargetedPracticeTextChange: (String) -> Unit,
+    onTargetedPracticeFocused: suspend () -> Unit,
     tempo: Float,
     onTempoChange: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val scrollState = rememberScrollState()
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val scope = rememberCoroutineScope()
+
     Column(
-        modifier = modifier.padding(horizontal = 20.dp)
+        modifier = modifier
+            .verticalScroll(scrollState)
+            .padding(horizontal = 20.dp)
     ) {
         Text(
             text = "Exercise settings",
@@ -77,6 +97,49 @@ internal fun OptionsSheetContent(
                 HorizontalDivider(color = Divider)
                 Spacer(modifier = Modifier.height(18.dp))
 
+                OutlinedTextField(
+                    value = targetedPracticeText,
+                    onValueChange = onTargetedPracticeTextChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 10.dp)
+                        .bringIntoViewRequester(bringIntoViewRequester)
+                        .onFocusEvent { focusState ->
+                            if (focusState.isFocused) {
+                                scope.launch {
+                                    onTargetedPracticeFocused()
+                                    delay(TargetedPracticeBringIntoViewDelayMillis)
+                                    bringIntoViewRequester.bringIntoView()
+                                }
+                            }
+                        },
+                    label = { Text("Targeted practice") },
+                    placeholder = { Text("e.g. left hand, accidentals, small jumps") },
+                    supportingText = { Text("Used for the next exercise.") },
+                    minLines = 3,
+                    maxLines = 5,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = Charcoal),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Charcoal,
+                        unfocusedTextColor = Charcoal,
+                        focusedContainerColor = Paper,
+                        unfocusedContainerColor = Paper,
+                        focusedBorderColor = WarmAccent,
+                        unfocusedBorderColor = Stroke,
+                        focusedLabelColor = WarmAccent,
+                        unfocusedLabelColor = TextSecondary,
+                        cursorColor = WarmAccent,
+                        focusedPlaceholderColor = TextSecondary,
+                        unfocusedPlaceholderColor = TextSecondary,
+                        focusedSupportingTextColor = TextSecondary,
+                        unfocusedSupportingTextColor = TextSecondary
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(18.dp))
+                HorizontalDivider(color = Divider)
+                Spacer(modifier = Modifier.height(18.dp))
+
                 Text(
                     text = "Tempo",
                     color = Charcoal,
@@ -103,9 +166,11 @@ internal fun OptionsSheetContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(36.dp))
     }
 }
+
+private const val TargetedPracticeBringIntoViewDelayMillis = 250L
 
 @Composable
 private fun DifficultySelector(

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/ScoreViewModel.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/ScoreViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clefrun.app.coach.ExercisePlan
+import com.clefrun.app.coach.ExercisePlanRequest
 import com.clefrun.app.coach.ExercisePlanProvider
 import com.clefrun.app.coach.LocalExercisePlanProvider
 import com.clefrun.core.Difficulty
@@ -18,7 +19,7 @@ import kotlinx.coroutines.withContext
 
 class ScoreViewModel(
     private val exercisePlanProvider: ExercisePlanProvider = LocalExercisePlanProvider(),
-    private val generateXml: suspend (seed: Long, difficulty: Difficulty) -> String = ::generateExerciseXml,
+    private val generateXml: suspend (ExercisePlan) -> String = ::generateExerciseXml,
     private val generationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
     private var nextSeed by mutableLongStateOf(2L)
@@ -31,6 +32,9 @@ class ScoreViewModel(
         private set
 
     var currentExercisePlan: ExercisePlan? by mutableStateOf(null)
+        private set
+
+    var targetedPracticeText by mutableStateOf("")
         private set
 
     init {
@@ -46,18 +50,28 @@ class ScoreViewModel(
         nextSeed += 1
     }
 
+    fun onTargetedPracticeTextChange(text: String) {
+        targetedPracticeText = text.take(MaxTargetedPracticeTextLength)
+    }
+
     private fun generateExercise(seed: Long, difficulty: Difficulty) {
         generationJob?.cancel()
-        val exercisePlan = exercisePlanProvider.nextSightReadingPlan(
+        val request = ExercisePlanRequest(
             seed = seed,
-            difficulty = difficulty
+            difficulty = difficulty,
+            targetedPracticeText = targetedPracticeText.ifBlank { null }
         )
+        val exercisePlan = exercisePlanProvider.nextSightReadingPlan(request)
         currentExercisePlan = exercisePlan
         generationJob = viewModelScope.launch {
             val musicXml = withContext(generationDispatcher) {
-                generateXml(seed, difficulty)
+                generateXml(exercisePlan)
             }
             currentMusicXml = musicXml
         }
+    }
+
+    private companion object {
+        const val MaxTargetedPracticeTextLength = 255
     }
 }

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingRoute.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingRoute.kt
@@ -15,7 +15,9 @@ fun SightReadingRoute(
             coach = exercisePlan.coach,
             coachTipId = exercisePlan.id,
             selectedDifficulty = scoreViewModel.selectedDifficulty,
+            targetedPracticeText = scoreViewModel.targetedPracticeText,
             onDifficultySelected = scoreViewModel::onDifficultySelected,
+            onTargetedPracticeTextChange = scoreViewModel::onTargetedPracticeTextChange,
             onNewExercise = scoreViewModel::onNewExercise,
             modifier = modifier
         )

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingScreen.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -59,7 +60,9 @@ internal fun SightReadingScreen(
     coach: CoachContent,
     coachTipId: String,
     selectedDifficulty: Difficulty,
+    targetedPracticeText: String,
     onDifficultySelected: (Difficulty) -> Unit,
+    onTargetedPracticeTextChange: (String) -> Unit,
     onNewExercise: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -78,7 +81,9 @@ internal fun SightReadingScreen(
             coach = coach,
             coachTipId = coachTipId,
             selectedDifficulty = selectedDifficulty,
+            targetedPracticeText = targetedPracticeText,
             onDifficultySelected = onDifficultySelected,
+            onTargetedPracticeTextChange = onTargetedPracticeTextChange,
             onRegenerate = onNewExercise,
             modifier = modifier
         )
@@ -92,7 +97,9 @@ private fun PortraitScoreScreen(
     coach: CoachContent,
     coachTipId: String,
     selectedDifficulty: Difficulty,
+    targetedPracticeText: String,
     onDifficultySelected: (Difficulty) -> Unit,
+    onTargetedPracticeTextChange: (String) -> Unit,
     onRegenerate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -132,11 +139,17 @@ private fun PortraitScoreScreen(
             OptionsSheetContent(
                 selectedDifficulty = selectedDifficulty,
                 onDifficultySelected = onDifficultySelected,
+                targetedPracticeText = targetedPracticeText,
+                onTargetedPracticeTextChange = onTargetedPracticeTextChange,
+                onTargetedPracticeFocused = {
+                    scaffoldState.bottomSheetState.expand()
+                },
                 tempo = tempo,
                 onTempoChange = { tempo = it },
                 modifier = Modifier
                     .fillMaxWidth()
                     .navigationBarsPadding()
+                    .imePadding()
                     .padding(bottom = 12.dp)
             )
         },

--- a/app/src/test/java/com/clefrun/app/coach/LocalExercisePlanProviderTest.kt
+++ b/app/src/test/java/com/clefrun/app/coach/LocalExercisePlanProviderTest.kt
@@ -49,11 +49,33 @@ class LocalExercisePlanProviderTest {
     fun `maps targeted practice text to supported focus`() {
         val provider = LocalExercisePlanProvider()
 
+        assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("left hand"))
         assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("bass clef"))
         assertEquals(ExerciseFocus.ACCIDENTALS, provider.focusForText("sharps and flats"))
+        assertEquals(ExerciseFocus.ACCIDENTALS, provider.focusForText("accidentals"))
         assertEquals(ExerciseFocus.SMALL_LEAPS, provider.focusForText("small jumps"))
+        assertEquals(ExerciseFocus.SMALL_LEAPS, provider.focusForText("leaps"))
         assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("chords"))
         assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("something else"))
+    }
+
+    @Test
+    fun `does not match targeted practice substrings inside larger words`() {
+        val provider = LocalExercisePlanProvider()
+
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("cleft hand"))
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("flatware"))
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("jumper"))
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("jumping"))
+    }
+
+    @Test
+    fun `tokenizes targeted practice on non letter separators`() {
+        val provider = LocalExercisePlanProvider()
+
+        assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("LEFT-hand"))
+        assertEquals(ExerciseFocus.ACCIDENTALS, provider.focusForText("sharp/flat"))
+        assertEquals(ExerciseFocus.SMALL_LEAPS, provider.focusForText("small,jumps"))
     }
 
     private fun LocalExercisePlanProvider.focusForText(text: String): ExerciseFocus {

--- a/app/src/test/java/com/clefrun/app/coach/LocalExercisePlanProviderTest.kt
+++ b/app/src/test/java/com/clefrun/app/coach/LocalExercisePlanProviderTest.kt
@@ -1,37 +1,68 @@
 package com.clefrun.app.coach
 
 import com.clefrun.core.Difficulty
+import com.clefrun.core.ExerciseFocus
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LocalExercisePlanProviderTest {
 
     @Test
-    fun `cycles through predefined sight reading tips`() {
+    fun `empty targeted practice uses read ahead plan`() {
         val provider = LocalExercisePlanProvider()
 
-        val first = provider.nextSightReadingPlan(seed = 1L, difficulty = Difficulty.EASY)
-        val second = provider.nextSightReadingPlan(seed = 2L, difficulty = Difficulty.EASY)
-        val third = provider.nextSightReadingPlan(seed = 3L, difficulty = Difficulty.EASY)
-        val fourth = provider.nextSightReadingPlan(seed = 4L, difficulty = Difficulty.EASY)
+        val plan = provider.nextSightReadingPlan(
+            ExercisePlanRequest(
+                seed = 1L,
+                difficulty = Difficulty.EASY,
+                targetedPracticeText = null
+            )
+        )
 
-        assertEquals("Read ahead", first.coach.focusLabel)
-        assertEquals("Block chords together", second.coach.focusLabel)
-        assertEquals("Steady rhythm", third.coach.focusLabel)
-        assertEquals(first.coach, fourth.coach)
+        assertEquals(ExerciseFocus.READ_AHEAD, plan.generatorFocus)
+        assertEquals("Read ahead", plan.coach.focusLabel)
     }
 
     @Test
     fun `creates local sight reading plan for selected difficulty`() {
         val provider = LocalExercisePlanProvider()
 
-        val plan = provider.nextSightReadingPlan(seed = 7L, difficulty = Difficulty.HARD)
+        val plan = provider.nextSightReadingPlan(
+            ExercisePlanRequest(
+                seed = 7L,
+                difficulty = Difficulty.HARD,
+                targetedPracticeText = "left hand"
+            )
+        )
 
         assertEquals("local-sight-reading-7", plan.id)
+        assertEquals(7L, plan.seed)
         assertEquals(ExercisePlanSource.LOCAL, plan.source)
         assertEquals(ExercisePlanMode.SIGHT_READING, plan.mode)
         assertEquals(Difficulty.HARD, plan.difficulty)
+        assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, plan.generatorFocus)
         assertEquals(plan.coach.focusLabel, plan.focus)
         assertEquals(emptyList<String>(), plan.constraints)
+    }
+
+    @Test
+    fun `maps targeted practice text to supported focus`() {
+        val provider = LocalExercisePlanProvider()
+
+        assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("bass clef"))
+        assertEquals(ExerciseFocus.ACCIDENTALS, provider.focusForText("sharps and flats"))
+        assertEquals(ExerciseFocus.SMALL_LEAPS, provider.focusForText("small jumps"))
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("chords"))
+        assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("something else"))
+    }
+
+    private fun LocalExercisePlanProvider.focusForText(text: String): ExerciseFocus {
+        return nextSightReadingPlan(
+            ExercisePlanRequest(
+                seed = 1L,
+                difficulty = Difficulty.EASY,
+                targetedPracticeText = text
+            )
+        ).generatorFocus
     }
 }

--- a/app/src/test/java/com/clefrun/app/feature/sightreading/ScoreViewModelTest.kt
+++ b/app/src/test/java/com/clefrun/app/feature/sightreading/ScoreViewModelTest.kt
@@ -5,8 +5,10 @@ import com.clefrun.app.coach.CoachContent
 import com.clefrun.app.coach.ExercisePlan
 import com.clefrun.app.coach.ExercisePlanMode
 import com.clefrun.app.coach.ExercisePlanProvider
+import com.clefrun.app.coach.ExercisePlanRequest
 import com.clefrun.app.coach.ExercisePlanSource
 import com.clefrun.core.Difficulty
+import com.clefrun.core.ExerciseFocus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -27,7 +29,7 @@ class ScoreViewModelTest {
 
             advanceUntilIdle()
 
-            assertEquals("xml-1-EASY", viewModel.currentMusicXml)
+            assertEquals("xml-1-EASY-READ_AHEAD", viewModel.currentMusicXml)
             val exercisePlan = checkNotNull(viewModel.currentExercisePlan)
             assertEquals("plan-1-EASY", exercisePlan.id)
             assertEquals("Focus 1", exercisePlan.coach.focusLabel)
@@ -37,16 +39,25 @@ class ScoreViewModelTest {
     @Test
     fun `initial state requests exercise plan once for easy seed one`() =
         runTest(mainDispatcherRule.dispatcher) {
-            val providerRequests = mutableListOf<Pair<Long, Difficulty>>()
+            val providerRequests = mutableListOf<ExercisePlanRequest>()
 
             createViewModel(
-                exercisePlanProvider = ExercisePlanProvider { seed, difficulty ->
-                    providerRequests += seed to difficulty
-                    createExercisePlan(seed = seed, difficulty = difficulty)
+                exercisePlanProvider = ExercisePlanProvider { request ->
+                    providerRequests += request
+                    createExercisePlan(seed = request.seed, difficulty = request.difficulty)
                 }
             )
 
-            assertEquals(listOf(1L to Difficulty.EASY), providerRequests)
+            assertEquals(
+                listOf(
+                    ExercisePlanRequest(
+                        seed = 1L,
+                        difficulty = Difficulty.EASY,
+                        targetedPracticeText = null
+                    )
+                ),
+                providerRequests
+            )
         }
 
     @Test
@@ -58,7 +69,7 @@ class ScoreViewModelTest {
             viewModel.onNewExercise()
             advanceUntilIdle()
 
-            assertEquals("xml-2-EASY", viewModel.currentMusicXml)
+            assertEquals("xml-2-EASY-READ_AHEAD", viewModel.currentMusicXml)
             val exercisePlan = checkNotNull(viewModel.currentExercisePlan)
             assertEquals("plan-2-EASY", exercisePlan.id)
             assertEquals("Focus 2", exercisePlan.coach.focusLabel)
@@ -74,30 +85,76 @@ class ScoreViewModelTest {
             viewModel.onNewExercise()
             advanceUntilIdle()
 
-            assertEquals("xml-2-HARD", viewModel.currentMusicXml)
+            assertEquals("xml-2-HARD-READ_AHEAD", viewModel.currentMusicXml)
             val exercisePlan = checkNotNull(viewModel.currentExercisePlan)
             assertEquals("plan-2-HARD", exercisePlan.id)
             assertEquals(Difficulty.HARD, exercisePlan.difficulty)
         }
 
+    @Test
+    fun `targeted practice text is passed to next new exercise request`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            val providerRequests = mutableListOf<ExercisePlanRequest>()
+            val viewModel = createViewModel(
+                exercisePlanProvider = ExercisePlanProvider { request ->
+                    providerRequests += request
+                    createExercisePlan(
+                        seed = request.seed,
+                        difficulty = request.difficulty,
+                        generatorFocus = if (request.targetedPracticeText == "left hand") {
+                            ExerciseFocus.LEFT_HAND_STABILITY
+                        } else {
+                            ExerciseFocus.READ_AHEAD
+                        }
+                    )
+                }
+            )
+            advanceUntilIdle()
+
+            viewModel.onTargetedPracticeTextChange("left hand")
+
+            assertEquals("xml-1-EASY-READ_AHEAD", viewModel.currentMusicXml)
+
+            viewModel.onNewExercise()
+            advanceUntilIdle()
+
+            assertEquals("left hand", providerRequests.last().targetedPracticeText)
+            assertEquals("xml-2-EASY-LEFT_HAND_STABILITY", viewModel.currentMusicXml)
+        }
+
+    @Test
+    fun `targeted practice text is clamped to max length`() {
+        val viewModel = createViewModel()
+
+        viewModel.onTargetedPracticeTextChange("a".repeat(300))
+
+        assertEquals(255, viewModel.targetedPracticeText.length)
+    }
+
     private fun createViewModel(
-        exercisePlanProvider: ExercisePlanProvider = ExercisePlanProvider { seed, difficulty ->
-            createExercisePlan(seed = seed, difficulty = difficulty)
+        exercisePlanProvider: ExercisePlanProvider = ExercisePlanProvider { request ->
+            createExercisePlan(seed = request.seed, difficulty = request.difficulty)
         },
     ): ScoreViewModel {
         return ScoreViewModel(
             exercisePlanProvider = exercisePlanProvider,
-            generateXml = { seed, difficulty -> "xml-$seed-$difficulty" },
+            generateXml = { plan -> "xml-${plan.seed}-${plan.difficulty}-${plan.generatorFocus}" },
             generationDispatcher = mainDispatcherRule.dispatcher,
         )
     }
 
-    private fun createExercisePlan(seed: Long, difficulty: Difficulty): ExercisePlan {
+    private fun createExercisePlan(
+        seed: Long,
+        difficulty: Difficulty,
+        generatorFocus: ExerciseFocus = ExerciseFocus.READ_AHEAD
+    ): ExercisePlan {
         return ExercisePlan(
             id = "plan-$seed-$difficulty",
+            seed = seed,
             source = ExercisePlanSource.LOCAL,
             mode = ExercisePlanMode.SIGHT_READING,
             difficulty = difficulty,
+            generatorFocus = generatorFocus,
             focus = "Focus $seed",
             coach = CoachContent(
                 title = "Coach tip",

--- a/core/src/main/kotlin/com/clefrun/core/Domain.kt
+++ b/core/src/main/kotlin/com/clefrun/core/Domain.kt
@@ -15,6 +15,13 @@ enum class Difficulty {
     HARD
 }
 
+enum class ExerciseFocus {
+    READ_AHEAD,
+    LEFT_HAND_STABILITY,
+    ACCIDENTALS,
+    SMALL_LEAPS
+}
+
 data class Bar(
     val number: Int,
     val chord: ChordFunction,

--- a/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
+++ b/core/src/main/kotlin/com/clefrun/core/RuleBasedGenerator.kt
@@ -4,9 +4,13 @@ import kotlin.math.abs
 import kotlin.random.Random
 
 object RuleBasedGenerator {
-    fun generate(seed: Long, difficulty: Difficulty = Difficulty.MEDIUM): Exercise {
+    fun generate(
+        seed: Long,
+        difficulty: Difficulty = Difficulty.MEDIUM,
+        focus: ExerciseFocus = ExerciseFocus.READ_AHEAD
+    ): Exercise {
         val random = Random(seed)
-        val profile = difficulty.profile()
+        val profile = difficulty.profile().forFocus(focus)
         val chords = buildChordProgression(random)
 
         var previousRhMidi: Int? = null
@@ -21,7 +25,8 @@ object RuleBasedGenerator {
                 previousRhMidi = previousRhMidi,
                 previousShape = previousShape,
                 globalRecentMidis = recentRhMidis,
-                profile = profile
+                profile = profile,
+                focus = focus
             )
 
             maybeInsertChromaticApproach(
@@ -49,7 +54,7 @@ object RuleBasedGenerator {
                         beatStart = it.beatStart
                     )
                 },
-                leftHand = generateLeftHand(random, chord, profile)
+                leftHand = generateLeftHand(random, chord, profile, focus)
             )
         }
 
@@ -132,6 +137,18 @@ private fun Difficulty.profile(): DifficultyProfile {
     }
 }
 
+private fun DifficultyProfile.forFocus(focus: ExerciseFocus): DifficultyProfile {
+    return when (focus) {
+        ExerciseFocus.ACCIDENTALS -> copy(
+            accidentalProbability = when {
+                accidentalProbability <= 0.0 -> 0.12
+                else -> (accidentalProbability + 0.12).coerceAtMost(0.48)
+            }
+        )
+        else -> this
+    }
+}
+
 private fun buildChordProgression(random: Random): List<ChordFunction> {
     val phraseA = buildPhrase(random)
     val phraseB = buildPhrase(random, avoidOpenings = setOf(phraseA.first(), phraseA.last()))
@@ -177,7 +194,8 @@ private fun generateRightHandBar(
     previousRhMidi: Int?,
     previousShape: List<Int>?,
     globalRecentMidis: List<Int>,
-    profile: DifficultyProfile
+    profile: DifficultyProfile,
+    focus: ExerciseFocus
 ): MutableList<MutableRhEvent> {
     var attempt = 0
     while (true) {
@@ -196,7 +214,8 @@ private fun generateRightHandBar(
                 contourDirection = contourDirection,
                 weakBeat = beat == 2 || beat == 4,
                 recent = (globalRecentMidis + events.takeLast(2).map { it.midi }).takeLast(3),
-                profile = profile
+                profile = profile,
+                focus = focus
             )
             events += MutableRhEvent(midi = midi, duration = duration, beatStart = beat)
             localPrev = midi
@@ -254,13 +273,19 @@ private fun rightHandRhythmPattern(random: Random, profile: DifficultyProfile): 
 private fun generateLeftHand(
     random: Random,
     chord: ChordFunction,
-    profile: DifficultyProfile
+    profile: DifficultyProfile,
+    focus: ExerciseFocus
 ): List<NoteEvent> {
     val root = leftHandRootMidi(chord)
     val third = leftHandThirdMidi(chord)
     val fifth = leftHandFifthMidi(chord)
 
-    val pattern: List<Pair<Int, Duration>> = when (profile.leftHandStyle) {
+    val pattern: List<Pair<Int, Duration>> = if (focus == ExerciseFocus.LEFT_HAND_STABILITY) {
+        listOf(
+            root to Duration.HALF,
+            fifth to Duration.HALF
+        )
+    } else when (profile.leftHandStyle) {
         LeftHandStyle.EASY -> if (random.nextDouble() < 0.65) {
             listOf(root to Duration.WHOLE)
         } else {
@@ -324,7 +349,8 @@ private fun chooseRightHandMidi(
     contourDirection: Int,
     weakBeat: Boolean,
     recent: List<Int>,
-    profile: DifficultyProfile
+    profile: DifficultyProfile,
+    focus: ExerciseFocus
 ): Int {
     val candidates = profile.rightHandRange.filter { midi ->
         isCmajor(midi) && (!mustBeChordTone || isChordTone(midi, chord))
@@ -357,6 +383,15 @@ private fun chooseRightHandMidi(
 
             if (diff >= 5) {
                 weight = (weight - profile.largeLeapWeightPenalty).coerceAtLeast(1)
+            }
+
+            if (focus == ExerciseFocus.SMALL_LEAPS) {
+                weight = when {
+                    diff in 3..5 -> weight + 3
+                    diff > 5 -> (weight - 2).coerceAtLeast(1)
+                    diff == 0 -> (weight - 1).coerceAtLeast(1)
+                    else -> weight
+                }
             }
 
             if (weakBeat) {

--- a/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
+++ b/core/src/test/kotlin/com/clefrun/core/RuleBasedGeneratorTest.kt
@@ -134,6 +134,99 @@ class RuleBasedGeneratorTest {
         assertTrue("Hard should cover a wider RH span than easy", hardRange > easyRange)
     }
 
+    @Test
+    fun leftHandStabilityFocusUsesSteadyHalfNotePattern() {
+        val seeds = (1L..12L).toList()
+
+        Difficulty.entries.forEach { difficulty ->
+            seeds.forEach { seed ->
+                val exercise = RuleBasedGenerator.generate(
+                    seed = seed,
+                    difficulty = difficulty,
+                    focus = ExerciseFocus.LEFT_HAND_STABILITY
+                )
+
+                exercise.bars.forEach { bar ->
+                    assertEquals(listOf(Duration.HALF, Duration.HALF), bar.leftHand.map { it.duration })
+                    assertTrue(
+                        "LH must stay below RH (seed=$seed, bar=${bar.number})",
+                        bar.leftHand.maxOf { toMidi(requireNotNull(it.pitch)) } <
+                            bar.rightHand.minOf { toMidi(requireNotNull(it.pitch)) }
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun accidentalsFocusBiasesExistingChromaticApproachBehavior() {
+        val seeds = (1L..80L).toList()
+
+        val defaultAccidentals = seeds.sumOf { seed ->
+            countAccidentals(RuleBasedGenerator.generate(seed = seed, difficulty = Difficulty.MEDIUM))
+        }
+        val focusedAccidentals = seeds.sumOf { seed ->
+            countAccidentals(
+                RuleBasedGenerator.generate(
+                    seed = seed,
+                    difficulty = Difficulty.MEDIUM,
+                    focus = ExerciseFocus.ACCIDENTALS
+                )
+            )
+        }
+
+        assertTrue("Accidentals focus should increase altered RH notes", focusedAccidentals > defaultAccidentals)
+    }
+
+    @Test
+    fun accidentalsFocusKeepsResolutionConstraint() {
+        val seeds = (1L..120L).toList()
+
+        Difficulty.entries.forEach { difficulty ->
+            seeds.forEach { seed ->
+                val exercise = RuleBasedGenerator.generate(
+                    seed = seed,
+                    difficulty = difficulty,
+                    focus = ExerciseFocus.ACCIDENTALS
+                )
+                exercise.bars.forEach { bar ->
+                    bar.rightHand.forEachIndexed { index, note ->
+                        val pitch = note.pitch ?: return@forEachIndexed
+                        if (pitch.alter == 0) return@forEachIndexed
+
+                        assertTrue(
+                            "Accidental note must not be last in bar (seed=$seed, bar=${bar.number})",
+                            index + 1 < bar.rightHand.size
+                        )
+                        val nextPitch = requireNotNull(bar.rightHand[index + 1].pitch)
+                        assertEquals(1, abs(toMidi(pitch) - toMidi(nextPitch)))
+                        assertTrue("Resolution note must be chord tone", isChordTone(nextPitch, bar.chord))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun smallLeapsFocusBiasesRightHandTowardControlledLeaps() {
+        val seeds = (1L..80L).toList()
+
+        val defaultSmallLeaps = seeds.sumOf { seed ->
+            countSmallLeaps(RuleBasedGenerator.generate(seed = seed, difficulty = Difficulty.MEDIUM))
+        }
+        val focusedSmallLeaps = seeds.sumOf { seed ->
+            countSmallLeaps(
+                RuleBasedGenerator.generate(
+                    seed = seed,
+                    difficulty = Difficulty.MEDIUM,
+                    focus = ExerciseFocus.SMALL_LEAPS
+                )
+            )
+        }
+
+        assertTrue("Small leaps focus should increase RH intervals of a third to fourth", focusedSmallLeaps > defaultSmallLeaps)
+    }
+
     private fun isChordTone(pitch: Pitch, chord: ChordFunction): Boolean {
         val pitchClass = ((stepToPitchClass(pitch.step) + pitch.alter) % 12 + 12) % 12
         val tones = when (chord) {
@@ -168,6 +261,14 @@ class RuleBasedGeneratorTest {
             .map { toMidi(requireNotNull(it.pitch)) }
         if (midis.isEmpty()) return 0
         return midis.maxOrNull()!! - midis.minOrNull()!!
+    }
+
+    private fun countSmallLeaps(exercise: Exercise): Int {
+        return exercise.bars.sumOf { bar ->
+            bar.rightHand
+                .zipWithNext { a, b -> abs(toMidi(requireNotNull(a.pitch)) - toMidi(requireNotNull(b.pitch))) }
+                .count { it in 3..5 }
+        }
     }
 
     private fun stepToPitchClass(step: Step): Int {

--- a/docs/manual-smoke-test.md
+++ b/docs/manual-smoke-test.md
@@ -8,28 +8,35 @@
 4. Tap `Sight Reading` and confirm a score renders automatically.
 5. Tap `New` a few times and confirm the score changes.
 6. Select a different difficulty in portrait and tap `New`.
-7. Rotate to landscape.
-8. Confirm the same score remains visible and the screen shows only the score surface plus the compact next button.
-9. Rotate back to portrait.
-10. Confirm the same score and selected difficulty are still preserved.
-11. Return to the Practice Hub and tap `Scales, Arpeggios & Cadences`.
-12. Confirm the screen opens directly into a practice page with a single paper score surface and a compact options button in the top-right.
-13. Open the bottom sheet and confirm `Mode` and `Key` controls live there, not in the header.
-14. Confirm only the currently curated combinations are enabled: `Major` mode with `C`, `F`, and `G` keys.
-15. Change between supported keys and confirm the score refreshes automatically.
-16. Confirm the score page contains `Scale`, `Arpeggio`, and `Cadence` together on the same rendered sheet.
-17. Confirm the `Scale` is shown as a 2-octave quarter-note pattern with visible fingering in both hands and no duplicated top turnaround note.
-18. Confirm the `Arpeggio` is shown for two hands over two octaves using quarter notes with visible fingering in both hands, and that the highest note is not repeated at the turnaround.
-19. Confirm the technical-practice page does not show placeholder rests just to pad out short bars.
-20. Confirm the `Cadence` shows right-hand chords, left-hand single bass notes, no fingering numbers, and begins as a clearly separate lower block on the same score page.
-21. Confirm measure numbers are not shown on the technical-practice page.
-22. Confirm the technical-practice page also omits the printed `4/4` indication.
-23. Confirm the bottom of the score has a bit more breathing room above the bottom sheet.
+7. Open the Sight Reading bottom sheet and confirm it shows a `Targeted practice` input with the placeholder `e.g. left hand, accidentals, small jumps`.
+8. Leave the field empty, tap `New`, and confirm the normal read-ahead coach behavior remains.
+9. Type `left hand`, tap `New`, and confirm the coach tip mentions left hand stability.
+10. Type `accidentals`, tap `New`, and confirm the coach tip mentions accidentals.
+11. Type `small jumps`, tap `New`, and confirm the coach tip mentions small leaps.
+12. Type `chords`, tap `New`, and confirm the coach tip does not give chord-specific instructions.
+13. Rotate to landscape.
+14. Confirm the same score remains visible and the screen shows only the score surface plus the compact next button.
+15. Rotate back to portrait.
+16. Confirm the same score, selected difficulty, and targeted practice text are still preserved.
+17. Return to the Practice Hub and tap `Scales, Arpeggios & Cadences`.
+18. Confirm the screen opens directly into a practice page with a single paper score surface and a compact options button in the top-right.
+19. Open the bottom sheet and confirm `Mode` and `Key` controls live there, not in the header.
+20. Confirm only the currently curated combinations are enabled: `Major` mode with `C`, `F`, and `G` keys.
+21. Change between supported keys and confirm the score refreshes automatically.
+22. Confirm the score page contains `Scale`, `Arpeggio`, and `Cadence` together on the same rendered sheet.
+23. Confirm the `Scale` is shown as a 2-octave quarter-note pattern with visible fingering in both hands and no duplicated top turnaround note.
+24. Confirm the `Arpeggio` is shown for two hands over two octaves using quarter notes with visible fingering in both hands, and that the highest note is not repeated at the turnaround.
+25. Confirm the technical-practice page does not show placeholder rests just to pad out short bars.
+26. Confirm the `Cadence` shows right-hand chords, left-hand single bass notes, no fingering numbers, and begins as a clearly separate lower block on the same score page.
+27. Confirm measure numbers are not shown on the technical-practice page.
+28. Confirm the technical-practice page also omits the printed `4/4` indication.
+29. Confirm the bottom of the score has a bit more breathing room above the bottom sheet.
 
 Expected result:
 - The app starts at Practice Hub and navigation between the three screens is clean.
 - Rotation does not regenerate the exercise.
 - Portrait keeps the existing controls and bottom sheet.
 - Landscape shows a clean score-only reading mode.
+- Targeted practice text affects only the next generated Sight Reading exercise and does not create chord-specific behavior.
 - The Scales screen opens directly into a practical notation-first workflow without extra setup clicks.
 - The technical-practice notation is stable and workbook-like, using curated quarter-note scale/arpeggio patterns, hidden filler spacing instead of visible placeholder rests, and controlled cadence spacing.


### PR DESCRIPTION
## Summary
- add optional targeted practice input to the Sight Reading bottom sheet
- map local practice text to supported ExercisePlan focuses and drive coach/generator from the same plan
- add conservative generator focus biases and keyboard-safe text field UX

## Tests
- ./gradlew test
- ./gradlew assembleDebug