### PR TITLE
Milestone 16: Backend integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,14 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("boolean", "REMOTE_EXERCISE_PLAN_ENABLED", "false")
+            buildConfigField("String", "REMOTE_EXERCISE_PLAN_BASE_URL", "\"http://10.0.2.2:8080\"")
+        }
         release {
             isMinifyEnabled = false
+            buildConfigField("boolean", "REMOTE_EXERCISE_PLAN_ENABLED", "false")
+            buildConfigField("String", "REMOTE_EXERCISE_PLAN_BASE_URL", "\"http://10.0.2.2:8080\"")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -37,6 +43,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -54,10 +61,15 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.core)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.collections.immutable)
+    implementation(libs.okhttp)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.junit.junit)
+    testImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:networkSecurityConfig="@xml/debug_network_security_config" />
+</manifest>

--- a/app/src/debug/res/xml/debug_network_security_config.xml
+++ b/app/src/debug/res/xml/debug_network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/ExercisePlanProviderFactory.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/ExercisePlanProviderFactory.kt
@@ -1,0 +1,24 @@
+package com.clefrun.app.data.exerciseplan
+
+import com.clefrun.app.BuildConfig
+import com.clefrun.app.data.exerciseplan.remote.RemoteExercisePlanConfig
+import com.clefrun.app.data.exerciseplan.remote.defaultRemoteExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.ExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.FallbackExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.LocalExercisePlanProvider
+
+object ExercisePlanProviderFactory {
+    fun create(): ExercisePlanProvider {
+        val localProvider = LocalExercisePlanProvider()
+        val remoteProvider = defaultRemoteExercisePlanProvider(
+            config = RemoteExercisePlanConfig(
+                enabled = BuildConfig.REMOTE_EXERCISE_PLAN_ENABLED,
+                baseUrl = BuildConfig.REMOTE_EXERCISE_PLAN_BASE_URL,
+            )
+        )
+        return FallbackExercisePlanProvider(
+            primary = remoteProvider,
+            fallback = localProvider,
+        )
+    }
+}

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanApi.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanApi.kt
@@ -1,0 +1,11 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface RemoteExercisePlanApi {
+    @POST("exercise-plan")
+    suspend fun createExercisePlan(
+        @Body request: RemoteExercisePlanRequestDto,
+    ): RemoteExercisePlanResponseDto
+}

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanConfig.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanConfig.kt
@@ -1,0 +1,6 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+data class RemoteExercisePlanConfig(
+    val enabled: Boolean,
+    val baseUrl: String,
+)

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanDefaults.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanDefaults.kt
@@ -1,0 +1,62 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+internal val RemoteJsonMediaType = "application/json; charset=utf-8".toMediaType()
+
+internal fun defaultJson(): Json {
+    return Json {
+        ignoreUnknownKeys = true
+    }
+}
+
+internal fun defaultOkHttpClient(): OkHttpClient {
+    return OkHttpClient.Builder()
+        .connectTimeout(3, TimeUnit.SECONDS)
+        .writeTimeout(3, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .build()
+}
+
+internal fun defaultRemoteExercisePlanApi(
+    config: RemoteExercisePlanConfig,
+    client: OkHttpClient = defaultOkHttpClient(),
+    json: Json = defaultJson(),
+): RemoteExercisePlanApi {
+    return defaultRetrofit(config, client, json)
+        .create(RemoteExercisePlanApi::class.java)
+}
+
+internal fun defaultRemoteExercisePlanProvider(
+    config: RemoteExercisePlanConfig,
+    client: OkHttpClient = defaultOkHttpClient(),
+    json: Json = defaultJson(),
+): RemoteExercisePlanProvider {
+    return RemoteExercisePlanProvider(
+        config = config,
+        api = defaultRemoteExercisePlanApi(config, client, json),
+    )
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun defaultRetrofit(
+    config: RemoteExercisePlanConfig,
+    client: OkHttpClient,
+    json: Json,
+): Retrofit {
+    return Retrofit.Builder()
+        .baseUrl(config.baseUrl.normalizedRetrofitBaseUrl())
+        .client(client)
+        .addConverterFactory(json.asConverterFactory(RemoteJsonMediaType))
+        .build()
+}
+
+private fun String.normalizedRetrofitBaseUrl(): String {
+    return trimEnd('/') + "/"
+}

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanDtos.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanDtos.kt
@@ -1,0 +1,66 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteExercisePlanRequestDto(
+    val difficulty: String,
+    val targetedPracticeText: String?,
+    val supportedFocuses: List<String>,
+)
+
+@Serializable
+data class RemoteExercisePlanResponseDto(
+    val focus: RemoteExerciseFocusDto,
+    val constraints: RemoteExercisePlanConstraintsDto,
+    val coach: RemoteCoachDto,
+)
+
+@Serializable
+data class RemoteExercisePlanConstraintsDto(
+    val accidentalDensity: RemoteAccidentalDensityDto,
+    val rightHandMotion: RemoteRightHandMotionDto,
+    val leftHandTexture: RemoteLeftHandTextureDto,
+    val maxLeap: RemoteMaxLeapDto,
+)
+
+@Serializable
+data class RemoteCoachDto(
+    val title: String,
+    val body: String,
+    val watchOut: String? = null,
+)
+
+@Serializable
+enum class RemoteExerciseFocusDto {
+    READ_AHEAD,
+    LEFT_HAND_STABILITY,
+    ACCIDENTALS,
+    SMALL_LEAPS
+}
+
+@Serializable
+enum class RemoteAccidentalDensityDto {
+    NONE,
+    LOW,
+    MEDIUM
+}
+
+@Serializable
+enum class RemoteRightHandMotionDto {
+    MOSTLY_STEPWISE,
+    STEPWISE_WITH_SMALL_LEAPS
+}
+
+@Serializable
+enum class RemoteLeftHandTextureDto {
+    SIMPLE_BASS,
+    STEADY_BASS
+}
+
+@Serializable
+enum class RemoteMaxLeapDto {
+    SECOND,
+    THIRD,
+    FOURTH
+}

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanException.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanException.kt
@@ -1,0 +1,6 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+class RemoteExercisePlanException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanMapper.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanMapper.kt
@@ -1,0 +1,80 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import com.clefrun.app.domain.exerciseplan.AccidentalDensity
+import com.clefrun.app.domain.exerciseplan.CoachContent
+import com.clefrun.app.domain.exerciseplan.ExercisePlan
+import com.clefrun.app.domain.exerciseplan.ExercisePlanConstraints
+import com.clefrun.app.domain.exerciseplan.ExercisePlanMode
+import com.clefrun.app.domain.exerciseplan.ExercisePlanRequest
+import com.clefrun.app.domain.exerciseplan.ExercisePlanSource
+import com.clefrun.app.domain.exerciseplan.LeftHandTexture
+import com.clefrun.app.domain.exerciseplan.MaxLeap
+import com.clefrun.app.domain.exerciseplan.RightHandMotion
+import com.clefrun.app.domain.exerciseplan.toDisplayLabel
+import com.clefrun.core.ExerciseFocus
+
+internal fun ExercisePlanRequest.toRemoteDto(): RemoteExercisePlanRequestDto {
+    return RemoteExercisePlanRequestDto(
+        difficulty = difficulty.name,
+        targetedPracticeText = targetedPracticeText,
+        supportedFocuses = ExerciseFocus.entries.map { it.name }
+    )
+}
+
+internal fun RemoteExercisePlanResponseDto.toExercisePlan(request: ExercisePlanRequest): ExercisePlan {
+    val focus = focus.toExerciseFocus()
+    val coachTitle = coach.title.trim()
+    val coachBody = coach.body.trim()
+    if (coachTitle.isBlank() || coachBody.isBlank()) {
+        throw RemoteExercisePlanException("Remote exercise plan coach content is blank.")
+    }
+
+    return ExercisePlan(
+        id = "remote-sight-reading-${request.seed}",
+        seed = request.seed,
+        source = ExercisePlanSource.REMOTE,
+        mode = ExercisePlanMode.SIGHT_READING,
+        difficulty = request.difficulty,
+        generatorFocus = focus,
+        focus = focus.toDisplayLabel(),
+        constraints = constraints.toExercisePlanConstraints(),
+        coach = CoachContent(
+            title = coachTitle,
+            focusLabel = focus.toDisplayLabel(),
+            body = coachBody,
+            watchOut = coach.watchOut?.trim()?.ifBlank { null },
+        ),
+    )
+}
+
+private fun RemoteExerciseFocusDto.toExerciseFocus(): ExerciseFocus {
+    return when (this) {
+        RemoteExerciseFocusDto.READ_AHEAD -> ExerciseFocus.READ_AHEAD
+        RemoteExerciseFocusDto.LEFT_HAND_STABILITY -> ExerciseFocus.LEFT_HAND_STABILITY
+        RemoteExerciseFocusDto.ACCIDENTALS -> ExerciseFocus.ACCIDENTALS
+        RemoteExerciseFocusDto.SMALL_LEAPS -> ExerciseFocus.SMALL_LEAPS
+    }
+}
+
+private fun RemoteExercisePlanConstraintsDto.toExercisePlanConstraints(): ExercisePlanConstraints {
+    return ExercisePlanConstraints(
+        accidentalDensity = when (accidentalDensity) {
+            RemoteAccidentalDensityDto.NONE -> AccidentalDensity.NONE
+            RemoteAccidentalDensityDto.LOW -> AccidentalDensity.LOW
+            RemoteAccidentalDensityDto.MEDIUM -> AccidentalDensity.MEDIUM
+        },
+        rightHandMotion = when (rightHandMotion) {
+            RemoteRightHandMotionDto.MOSTLY_STEPWISE -> RightHandMotion.MOSTLY_STEPWISE
+            RemoteRightHandMotionDto.STEPWISE_WITH_SMALL_LEAPS -> RightHandMotion.STEPWISE_WITH_SMALL_LEAPS
+        },
+        leftHandTexture = when (leftHandTexture) {
+            RemoteLeftHandTextureDto.SIMPLE_BASS -> LeftHandTexture.SIMPLE_BASS
+            RemoteLeftHandTextureDto.STEADY_BASS -> LeftHandTexture.STEADY_BASS
+        },
+        maxLeap = when (maxLeap) {
+            RemoteMaxLeapDto.SECOND -> MaxLeap.SECOND
+            RemoteMaxLeapDto.THIRD -> MaxLeap.THIRD
+            RemoteMaxLeapDto.FOURTH -> MaxLeap.FOURTH
+        },
+    )
+}

--- a/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanProvider.kt
+++ b/app/src/main/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanProvider.kt
@@ -1,0 +1,31 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import com.clefrun.app.domain.exerciseplan.ExercisePlan
+import com.clefrun.app.domain.exerciseplan.ExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.ExercisePlanRequest
+import java.io.IOException
+import kotlinx.serialization.SerializationException
+import retrofit2.HttpException
+
+class RemoteExercisePlanProvider(
+    private val config: RemoteExercisePlanConfig,
+    private val api: RemoteExercisePlanApi,
+) : ExercisePlanProvider {
+    override suspend fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan {
+        if (!config.enabled) {
+            throw RemoteExercisePlanException("Remote exercise plan provider is disabled.")
+        }
+
+        val responseDto = try {
+            api.createExercisePlan(request.toRemoteDto())
+        } catch (exception: HttpException) {
+            throw RemoteExercisePlanException("Remote exercise plan returned HTTP ${exception.code()}.", exception)
+        } catch (exception: IOException) {
+            throw RemoteExercisePlanException("Remote exercise plan request failed.", exception)
+        } catch (exception: SerializationException) {
+            throw RemoteExercisePlanException("Remote exercise plan response is invalid.", exception)
+        }
+
+        return responseDto.toExercisePlan(request)
+    }
+}

--- a/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExerciseFocusLabels.kt
+++ b/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExerciseFocusLabels.kt
@@ -1,0 +1,12 @@
+package com.clefrun.app.domain.exerciseplan
+
+import com.clefrun.core.ExerciseFocus
+
+fun ExerciseFocus.toDisplayLabel(): String {
+    return when (this) {
+        ExerciseFocus.READ_AHEAD -> "Read ahead"
+        ExerciseFocus.LEFT_HAND_STABILITY -> "Left hand stability"
+        ExerciseFocus.ACCIDENTALS -> "Accidentals"
+        ExerciseFocus.SMALL_LEAPS -> "Small leaps"
+    }
+}

--- a/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExercisePlan.kt
+++ b/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExercisePlan.kt
@@ -1,4 +1,4 @@
-package com.clefrun.app.coach
+package com.clefrun.app.domain.exerciseplan
 
 import com.clefrun.core.Difficulty
 import com.clefrun.core.ExerciseFocus
@@ -17,9 +17,38 @@ data class ExercisePlan(
     val difficulty: Difficulty,
     val generatorFocus: ExerciseFocus,
     val focus: String,
-    val constraints: List<String> = emptyList(),
+    val constraints: ExercisePlanConstraints = ExercisePlanConstraints(),
     val coach: CoachContent,
 )
+
+data class ExercisePlanConstraints(
+    val accidentalDensity: AccidentalDensity? = null,
+    val rightHandMotion: RightHandMotion? = null,
+    val leftHandTexture: LeftHandTexture? = null,
+    val maxLeap: MaxLeap? = null,
+)
+
+enum class AccidentalDensity {
+    NONE,
+    LOW,
+    MEDIUM
+}
+
+enum class RightHandMotion {
+    MOSTLY_STEPWISE,
+    STEPWISE_WITH_SMALL_LEAPS
+}
+
+enum class LeftHandTexture {
+    SIMPLE_BASS,
+    STEADY_BASS
+}
+
+enum class MaxLeap {
+    SECOND,
+    THIRD,
+    FOURTH
+}
 
 data class CoachContent(
     val title: String,
@@ -29,7 +58,8 @@ data class CoachContent(
 )
 
 enum class ExercisePlanSource {
-    LOCAL
+    LOCAL,
+    REMOTE
 }
 
 enum class ExercisePlanMode {

--- a/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExercisePlanProvider.kt
+++ b/app/src/main/java/com/clefrun/app/domain/exerciseplan/ExercisePlanProvider.kt
@@ -1,14 +1,14 @@
-package com.clefrun.app.coach
+package com.clefrun.app.domain.exerciseplan
 
 import com.clefrun.core.ExerciseFocus
 import java.util.Locale
 
 fun interface ExercisePlanProvider {
-    fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan
+    suspend fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan
 }
 
 class LocalExercisePlanProvider : ExercisePlanProvider {
-    override fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan {
+    override suspend fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan {
         val focus = focusFor(request.targetedPracticeText)
         val tip = tipFor(focus)
         return ExercisePlan(
@@ -52,22 +52,22 @@ private fun tipFor(focus: ExerciseFocus): CoachContent {
     return when (focus) {
         ExerciseFocus.READ_AHEAD -> CoachContent(
             title = "Coach tip",
-            focusLabel = "Read ahead",
+            focusLabel = focus.toDisplayLabel(),
             body = "Look one beat ahead and keep the pulse steady through the full phrase.",
         )
         ExerciseFocus.LEFT_HAND_STABILITY -> CoachContent(
             title = "Coach tip",
-            focusLabel = "Left hand stability",
+            focusLabel = focus.toDisplayLabel(),
             body = "Keep the left hand steady and light while reading the right hand one beat ahead.",
         )
         ExerciseFocus.ACCIDENTALS -> CoachContent(
             title = "Coach tip",
-            focusLabel = "Accidentals",
+            focusLabel = focus.toDisplayLabel(),
             body = "Scan for altered notes before you start, then keep the pulse steady when they appear.",
         )
         ExerciseFocus.SMALL_LEAPS -> CoachContent(
             title = "Coach tip",
-            focusLabel = "Small leaps",
+            focusLabel = focus.toDisplayLabel(),
             body = "Read the interval shape before moving, and prepare the next hand position early.",
         )
     }

--- a/app/src/main/java/com/clefrun/app/domain/exerciseplan/FallbackExercisePlanProvider.kt
+++ b/app/src/main/java/com/clefrun/app/domain/exerciseplan/FallbackExercisePlanProvider.kt
@@ -1,0 +1,18 @@
+package com.clefrun.app.domain.exerciseplan
+
+import kotlinx.coroutines.CancellationException
+
+class FallbackExercisePlanProvider(
+    private val primary: ExercisePlanProvider,
+    private val fallback: ExercisePlanProvider,
+) : ExercisePlanProvider {
+    override suspend fun nextSightReadingPlan(request: ExercisePlanRequest): ExercisePlan {
+        return try {
+            primary.nextSightReadingPlan(request)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
+            fallback.nextSightReadingPlan(request)
+        }
+    }
+}

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/ExerciseXmlFactory.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/ExerciseXmlFactory.kt
@@ -1,6 +1,6 @@
 package com.clefrun.app.feature.sightreading
 
-import com.clefrun.app.coach.ExercisePlan
+import com.clefrun.app.domain.exerciseplan.ExercisePlan
 import com.clefrun.core.MusicXmlWriter
 import com.clefrun.core.RuleBasedGenerator
 

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/ScoreViewModel.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/ScoreViewModel.kt
@@ -6,10 +6,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.clefrun.app.coach.ExercisePlan
-import com.clefrun.app.coach.ExercisePlanRequest
-import com.clefrun.app.coach.ExercisePlanProvider
-import com.clefrun.app.coach.LocalExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.ExercisePlan
+import com.clefrun.app.domain.exerciseplan.ExercisePlanRequest
+import com.clefrun.app.domain.exerciseplan.ExercisePlanProvider
+import com.clefrun.app.data.exerciseplan.ExercisePlanProviderFactory
 import com.clefrun.core.Difficulty
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class ScoreViewModel(
-    private val exercisePlanProvider: ExercisePlanProvider = LocalExercisePlanProvider(),
+    private val exercisePlanProvider: ExercisePlanProvider = ExercisePlanProviderFactory.create(),
     private val generateXml: suspend (ExercisePlan) -> String = ::generateExerciseXml,
     private val generationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
@@ -61,9 +61,10 @@ class ScoreViewModel(
             difficulty = difficulty,
             targetedPracticeText = targetedPracticeText.ifBlank { null }
         )
-        val exercisePlan = exercisePlanProvider.nextSightReadingPlan(request)
-        currentExercisePlan = exercisePlan
         generationJob = viewModelScope.launch {
+            // TODO: Add an explicit loading state so remote plan requests do not leave the score blank.
+            val exercisePlan = exercisePlanProvider.nextSightReadingPlan(request)
+            currentExercisePlan = exercisePlan
             val musicXml = withContext(generationDispatcher) {
                 generateXml(exercisePlan)
             }

--- a/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingScreen.kt
+++ b/app/src/main/java/com/clefrun/app/feature/sightreading/SightReadingScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.clefrun.app.coach.CoachContent
+import com.clefrun.app.domain.exerciseplan.CoachContent
 import com.clefrun.app.ui.coach.CoachBubble
 import com.clefrun.app.ui.coach.CoachTipPopup
 import com.clefrun.app.ui.score.ScoreSurface

--- a/app/src/main/java/com/clefrun/app/ui/coach/CoachTipPopup.kt
+++ b/app/src/main/java/com/clefrun/app/ui/coach/CoachTipPopup.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.clefrun.app.coach.CoachContent
+import com.clefrun.app.domain.exerciseplan.CoachContent
 import com.clefrun.app.ui.theme.Charcoal
 import com.clefrun.app.ui.theme.Paper
 import com.clefrun.app.ui.theme.TextSecondary

--- a/app/src/test/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanProviderTest.kt
+++ b/app/src/test/java/com/clefrun/app/data/exerciseplan/remote/RemoteExercisePlanProviderTest.kt
@@ -1,0 +1,250 @@
+package com.clefrun.app.data.exerciseplan.remote
+
+import com.clefrun.app.domain.exerciseplan.AccidentalDensity
+import com.clefrun.app.domain.exerciseplan.ExercisePlanConstraints
+import com.clefrun.app.domain.exerciseplan.ExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.ExercisePlanRequest
+import com.clefrun.app.domain.exerciseplan.ExercisePlanSource
+import com.clefrun.app.domain.exerciseplan.FallbackExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.LeftHandTexture
+import com.clefrun.app.domain.exerciseplan.LocalExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.MaxLeap
+import com.clefrun.app.domain.exerciseplan.RightHandMotion
+import com.clefrun.core.Difficulty
+import com.clefrun.core.ExerciseFocus
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class RemoteExercisePlanProviderTest {
+
+    @Test
+    fun `successful remote response maps to exercise plan`() = runTest {
+        withServer { server ->
+            server.enqueue(MockResponse().setResponseCode(200).setBody(successResponseJson()))
+            val provider = remoteProvider(server)
+
+            val plan = provider.nextSightReadingPlan(
+                ExercisePlanRequest(
+                    seed = 12L,
+                    difficulty = Difficulty.EASY,
+                    targetedPracticeText = "I struggle with accidentals"
+                )
+            )
+
+            assertEquals("remote-sight-reading-12", plan.id)
+            assertEquals(12L, plan.seed)
+            assertEquals(ExercisePlanSource.REMOTE, plan.source)
+            assertEquals(Difficulty.EASY, plan.difficulty)
+            assertEquals(ExerciseFocus.ACCIDENTALS, plan.generatorFocus)
+            assertEquals("Accidentals", plan.focus)
+            assertEquals("Sharps and Flats", plan.coach.title)
+            assertEquals("Accidentals", plan.coach.focusLabel)
+            assertEquals(
+                "Pay close attention to every accidental; they temporarily alter the pitch of the note.",
+                plan.coach.body
+            )
+            assertEquals("Don't forget to cancel accidentals with a natural sign.", plan.coach.watchOut)
+            assertEquals(
+                ExercisePlanConstraints(
+                    accidentalDensity = AccidentalDensity.LOW,
+                    rightHandMotion = RightHandMotion.MOSTLY_STEPWISE,
+                    leftHandTexture = LeftHandTexture.SIMPLE_BASS,
+                    maxLeap = MaxLeap.THIRD
+                ),
+                plan.constraints
+            )
+        }
+    }
+
+    @Test
+    fun `remote request sends difficulty targeted text and supported focuses`() = runTest {
+        withServer { server ->
+            server.enqueue(MockResponse().setResponseCode(200).setBody(successResponseJson()))
+            val provider = remoteProvider(server)
+
+            provider.nextSightReadingPlan(
+                ExercisePlanRequest(
+                    seed = 3L,
+                    difficulty = Difficulty.HARD,
+                    targetedPracticeText = "left hand"
+                )
+            )
+
+            val request = server.takeRequest()
+            val body = defaultJson().decodeFromString(
+                RemoteExercisePlanRequestDto.serializer(),
+                request.body.readUtf8()
+            )
+
+            assertEquals("/exercise-plan", request.path)
+            assertEquals("POST", request.method)
+            assertEquals("HARD", body.difficulty)
+            assertEquals("left hand", body.targetedPracticeText)
+            assertEquals(ExerciseFocus.entries.map { it.name }, body.supportedFocuses)
+        }
+    }
+
+    @Test
+    fun `non 2xx remote response fails`() = runTest {
+        withServer { server ->
+            server.enqueue(MockResponse().setResponseCode(500).setBody("{}"))
+            val provider = remoteProvider(server)
+
+            assertRemoteFailure {
+                provider.nextSightReadingPlan(defaultRequest())
+            }
+        }
+    }
+
+    @Test
+    fun `invalid json remote response fails`() = runTest {
+        withServer { server ->
+            server.enqueue(MockResponse().setResponseCode(200).setBody("not-json"))
+            val provider = remoteProvider(server)
+
+            assertRemoteFailure {
+                provider.nextSightReadingPlan(defaultRequest())
+            }
+        }
+    }
+
+    @Test
+    fun `unknown remote focus fails`() = runTest {
+        withServer { server ->
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(successResponseJson().replace("ACCIDENTALS", "CHORDS"))
+            )
+            val provider = remoteProvider(server)
+
+            assertRemoteFailure {
+                provider.nextSightReadingPlan(defaultRequest())
+            }
+        }
+    }
+
+    @Test
+    fun `blank remote coach content fails`() = runTest {
+        withServer { server ->
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(successResponseJson(title = " ", body = " "))
+            )
+            val provider = remoteProvider(server)
+
+            assertRemoteFailure {
+                provider.nextSightReadingPlan(defaultRequest())
+            }
+        }
+    }
+
+    @Test
+    fun `fallback provider returns local plan when remote is disabled`() = runTest {
+        val provider = FallbackExercisePlanProvider(
+            primary = defaultRemoteExercisePlanProvider(
+                config = RemoteExercisePlanConfig(
+                    enabled = false,
+                    baseUrl = "http://10.0.2.2:8080"
+                )
+            ),
+            fallback = LocalExercisePlanProvider()
+        )
+
+        val plan = provider.nextSightReadingPlan(
+            ExercisePlanRequest(
+                seed = 4L,
+                difficulty = Difficulty.MEDIUM,
+                targetedPracticeText = "accidentals"
+            )
+        )
+
+        assertEquals(ExercisePlanSource.LOCAL, plan.source)
+        assertEquals(ExerciseFocus.ACCIDENTALS, plan.generatorFocus)
+    }
+
+    @Test
+    fun `fallback provider returns local plan when primary fails`() = runTest {
+        val provider = FallbackExercisePlanProvider(
+            primary = ExercisePlanProvider { throw IOException("network down") },
+            fallback = LocalExercisePlanProvider()
+        )
+
+        val plan = provider.nextSightReadingPlan(
+            ExercisePlanRequest(
+                seed = 5L,
+                difficulty = Difficulty.MEDIUM,
+                targetedPracticeText = "left hand"
+            )
+        )
+
+        assertEquals(ExercisePlanSource.LOCAL, plan.source)
+        assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, plan.generatorFocus)
+    }
+
+    private fun remoteProvider(server: MockWebServer): RemoteExercisePlanProvider {
+        return defaultRemoteExercisePlanProvider(
+            config = RemoteExercisePlanConfig(
+                enabled = true,
+                baseUrl = server.url("/").toString()
+            ),
+            json = Json {
+                ignoreUnknownKeys = true
+            }
+        )
+    }
+
+    private fun defaultRequest(): ExercisePlanRequest {
+        return ExercisePlanRequest(
+            seed = 1L,
+            difficulty = Difficulty.EASY,
+            targetedPracticeText = "accidentals"
+        )
+    }
+
+    private fun successResponseJson(
+        title: String = "Sharps and Flats",
+        body: String = "Pay close attention to every accidental; they temporarily alter the pitch of the note.",
+    ): String {
+        return """
+            {
+              "focus": "ACCIDENTALS",
+              "constraints": {
+                "accidentalDensity": "LOW",
+                "rightHandMotion": "MOSTLY_STEPWISE",
+                "leftHandTexture": "SIMPLE_BASS",
+                "maxLeap": "THIRD"
+              },
+              "coach": {
+                "title": "$title",
+                "body": "$body",
+                "watchOut": "Don't forget to cancel accidentals with a natural sign."
+              }
+            }
+        """.trimIndent()
+    }
+
+    private suspend fun withServer(block: suspend (MockWebServer) -> Unit) {
+        val server = MockWebServer()
+        try {
+            block(server)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    private suspend fun assertRemoteFailure(block: suspend () -> Unit) {
+        try {
+            block()
+            fail("Expected RemoteExercisePlanException")
+        } catch (_: RemoteExercisePlanException) {
+        }
+    }
+}

--- a/app/src/test/java/com/clefrun/app/domain/exerciseplan/LocalExercisePlanProviderTest.kt
+++ b/app/src/test/java/com/clefrun/app/domain/exerciseplan/LocalExercisePlanProviderTest.kt
@@ -1,14 +1,15 @@
-package com.clefrun.app.coach
+package com.clefrun.app.domain.exerciseplan
 
 import com.clefrun.core.Difficulty
 import com.clefrun.core.ExerciseFocus
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LocalExercisePlanProviderTest {
 
     @Test
-    fun `empty targeted practice uses read ahead plan`() {
+    fun `empty targeted practice uses read ahead plan`() = runTest {
         val provider = LocalExercisePlanProvider()
 
         val plan = provider.nextSightReadingPlan(
@@ -24,7 +25,7 @@ class LocalExercisePlanProviderTest {
     }
 
     @Test
-    fun `creates local sight reading plan for selected difficulty`() {
+    fun `creates local sight reading plan for selected difficulty`() = runTest {
         val provider = LocalExercisePlanProvider()
 
         val plan = provider.nextSightReadingPlan(
@@ -42,11 +43,11 @@ class LocalExercisePlanProviderTest {
         assertEquals(Difficulty.HARD, plan.difficulty)
         assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, plan.generatorFocus)
         assertEquals(plan.coach.focusLabel, plan.focus)
-        assertEquals(emptyList<String>(), plan.constraints)
+        assertEquals(ExercisePlanConstraints(), plan.constraints)
     }
 
     @Test
-    fun `maps targeted practice text to supported focus`() {
+    fun `maps targeted practice text to supported focus`() = runTest {
         val provider = LocalExercisePlanProvider()
 
         assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("left hand"))
@@ -60,7 +61,7 @@ class LocalExercisePlanProviderTest {
     }
 
     @Test
-    fun `does not match targeted practice substrings inside larger words`() {
+    fun `does not match targeted practice substrings inside larger words`() = runTest {
         val provider = LocalExercisePlanProvider()
 
         assertEquals(ExerciseFocus.READ_AHEAD, provider.focusForText("cleft hand"))
@@ -70,7 +71,7 @@ class LocalExercisePlanProviderTest {
     }
 
     @Test
-    fun `tokenizes targeted practice on non letter separators`() {
+    fun `tokenizes targeted practice on non letter separators`() = runTest {
         val provider = LocalExercisePlanProvider()
 
         assertEquals(ExerciseFocus.LEFT_HAND_STABILITY, provider.focusForText("LEFT-hand"))
@@ -78,7 +79,7 @@ class LocalExercisePlanProviderTest {
         assertEquals(ExerciseFocus.SMALL_LEAPS, provider.focusForText("small,jumps"))
     }
 
-    private fun LocalExercisePlanProvider.focusForText(text: String): ExerciseFocus {
+    private suspend fun LocalExercisePlanProvider.focusForText(text: String): ExerciseFocus {
         return nextSightReadingPlan(
             ExercisePlanRequest(
                 seed = 1L,

--- a/app/src/test/java/com/clefrun/app/feature/sightreading/ScoreViewModelTest.kt
+++ b/app/src/test/java/com/clefrun/app/feature/sightreading/ScoreViewModelTest.kt
@@ -1,12 +1,12 @@
 package com.clefrun.app.feature.sightreading
 
 import com.clefrun.app.MainDispatcherRule
-import com.clefrun.app.coach.CoachContent
-import com.clefrun.app.coach.ExercisePlan
-import com.clefrun.app.coach.ExercisePlanMode
-import com.clefrun.app.coach.ExercisePlanProvider
-import com.clefrun.app.coach.ExercisePlanRequest
-import com.clefrun.app.coach.ExercisePlanSource
+import com.clefrun.app.domain.exerciseplan.CoachContent
+import com.clefrun.app.domain.exerciseplan.ExercisePlan
+import com.clefrun.app.domain.exerciseplan.ExercisePlanMode
+import com.clefrun.app.domain.exerciseplan.ExercisePlanProvider
+import com.clefrun.app.domain.exerciseplan.ExercisePlanRequest
+import com.clefrun.app.domain.exerciseplan.ExercisePlanSource
 import com.clefrun.core.Difficulty
 import com.clefrun.core.ExerciseFocus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,6 +47,7 @@ class ScoreViewModelTest {
                     createExercisePlan(seed = request.seed, difficulty = request.difficulty)
                 }
             )
+            advanceUntilIdle()
 
             assertEquals(
                 listOf(

--- a/docs/manual-smoke-test.md
+++ b/docs/manual-smoke-test.md
@@ -40,3 +40,20 @@ Expected result:
 - Targeted practice text affects only the next generated Sight Reading exercise and does not create chord-specific behavior.
 - The Scales screen opens directly into a practical notation-first workflow without extra setup clicks.
 - The technical-practice notation is stable and workbook-like, using curated quarter-note scale/arpeggio patterns, hidden filler spacing instead of visible placeholder rests, and controlled cadence spacing.
+
+## Optional Remote Exercise Plan Check
+
+Remote exercise plans are disabled by default. For local debug testing, temporarily enable `REMOTE_EXERCISE_PLAN_ENABLED` in the debug build config and rebuild.
+
+1. Start the ClefRun remote locally on port `8080`.
+2. Use `http://10.0.2.2:8080` from the Android emulator.
+3. For a physical device, temporarily override `REMOTE_EXERCISE_PLAN_BASE_URL` with the remote machine's LAN URL, for example `http://192.168.x.x:8080`.
+4. Launch the debug app, open Sight Reading, type `accidentals`, and tap `New`.
+5. Confirm the coach tip comes from the remote response.
+6. Stop the remote and tap `New` again.
+7. Confirm the app falls back to the local plan and does not crash.
+
+Expected result:
+- Debug builds keep remote plans disabled unless explicitly enabled for local testing.
+- Release behavior remains remote-disabled by default.
+- Missing, slow, or invalid remote responses fall back to local exercise plans.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ kotlinxSerializationCore = "1.9.0"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutines = "1.10.2"
 junitJunit = "4.12"
+okhttp = "4.12.0"
+retrofit = "3.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,9 +36,14 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "nav3Core" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 junit-junit = { group = "junit", name = "junit", version.ref = "junitJunit" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- integrate optional remote backend exercise plans into Sight Reading
- add Retrofit + OkHttp networking for the backend exercise plan endpoint
- preserve local exercise plan fallback when the backend is disabled or unavailable
- add remote exercise plan DTO mapping and MockWebServer coverage
Closes #18 